### PR TITLE
Shard Manager scanID detection fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.4.47</version>
+	<version>0.4.48</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 

--- a/src/main/java/com/checkmarx/sdk/ShardManager/ShardSessionTracker.java
+++ b/src/main/java/com/checkmarx/sdk/ShardManager/ShardSessionTracker.java
@@ -47,7 +47,8 @@ public class ShardSessionTracker {
             System.setOut(new PrintStream(baos, true, StandardCharsets.UTF_8.name()));
             r.run();
             String tokenStr = new String(baos.toByteArray());
-            return tokenStr.substring(174, 183);
+            int tokenPos = tokenStr.indexOf("ScanID") + 13;
+            return tokenStr.substring(tokenPos, (tokenPos+8));
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("End of the world, Java doesn't recognise UTF-8");
         } finally {


### PR DESCRIPTION
The scanID was read incorrectly from the Spring Boot log when PID was shorter then expected. This fix now expects the ScanID token to appear in the console log so that it can be located in order to properly figure out where the ScanID. When Shard Manager is turned on this requires that the (application.yml) file configuration be updated. The ScanID token needs to be added to the log configuration like this:

console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{15}){cyan}  ScanID [%clr(%X{cx}){blue}] %clr(:){faint} %replace(%m){'([\\|])','\\$1'}%n%wEx"