### PR TITLE
Support for post back mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.4.48</version>
+	<version>0.4.49</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 

--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -55,6 +55,8 @@ public class CxProperties {
     private String TEAM_PATH_SEPARATOR_9 = "/";
     private String TEAM_PATH_SEPARATOR_8 = "\\";
     private Boolean enableShardManager = false;
+    private Boolean enablePostActionMonitor = false;
+    private Integer postActionPostbackId = 0;
 
     private String portalUrl;
 
@@ -68,6 +70,14 @@ public class CxProperties {
 
     public String getPassword() {
         return this.password;
+    }
+
+    public boolean getEnablePostActionMonitor() {
+        return this.enablePostActionMonitor;
+    }
+
+    public Integer getPostActionPostbackId() {
+        return this.postActionPostbackId;
     }
 
     public boolean getEnableShardManager() {
@@ -208,6 +218,14 @@ public class CxProperties {
 
     public void setIncrementalThreshold(Integer incrementalThreshold){
         this.incrementalThreshold = incrementalThreshold;
+    }
+
+    public void setEnablePostActionMonitor(boolean enablePostActionMonitor) {
+        this.enablePostActionMonitor = enablePostActionMonitor;
+    }
+
+    public void setPostActionPostbackId(Integer postActionPostbackId) {
+        this.postActionPostbackId = postActionPostbackId;
     }
 
     public void setEnableShardManager(boolean enableShardManager) {

--- a/src/main/java/com/checkmarx/sdk/dto/cx/CxScanSettings.java
+++ b/src/main/java/com/checkmarx/sdk/dto/cx/CxScanSettings.java
@@ -6,7 +6,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonPropertyOrder({
         "projectId",
         "presetId",
-        "engineConfigurationId"
+        "engineConfigurationId",
+        "postScanActionId"
 })
 
 public class CxScanSettings {
@@ -16,12 +17,16 @@ public class CxScanSettings {
     public Integer presetId;
     @JsonProperty("engineConfigurationId")
     public Integer engineConfigurationId;
+    @JsonProperty("postScanActionId")
+    public Integer postScanActionId;
+
 
     @java.beans.ConstructorProperties({"projectId", "presetId", "engineConfigurationId"})
-    CxScanSettings(Integer projectId, Integer presetId, Integer engineConfigurationId) {
+    CxScanSettings(Integer projectId, Integer presetId, Integer engineConfigurationId, Integer postScanActionId) {
         this.projectId = projectId;
         this.presetId = presetId;
         this.engineConfigurationId = engineConfigurationId;
+        this.postScanActionId = postScanActionId;
     }
 
     public static CxScanSettingsBuilder builder() {
@@ -36,6 +41,10 @@ public class CxScanSettings {
         return this.presetId;
     }
 
+    public Integer getPostScanActionId() {
+        return this.postScanActionId;
+    }
+
     public Integer getEngineConfigurationId() {
         return this.engineConfigurationId;
     }
@@ -48,18 +57,23 @@ public class CxScanSettings {
         this.presetId = presetId;
     }
 
+    public void setPostScanActionId(Integer postScanActionId) {
+        this.postScanActionId = postScanActionId;
+    }
+
     public void setEngineConfigurationId(Integer engineConfigurationId) {
         this.engineConfigurationId = engineConfigurationId;
     }
 
     public String toString() {
-        return "CxScanSettings(projectId=" + this.getProjectId() + ", presetId=" + this.getPresetId() + ", engineConfigurationId=" + this.getEngineConfigurationId() + ")";
+        return "CxScanSettings(projectId=" + this.getProjectId() + ", presetId=" + this.getPresetId() + ", engineConfigurationId=" + this.getEngineConfigurationId() + ", postScanActionId=" + this.postScanActionId + ")";
     }
 
     public static class CxScanSettingsBuilder {
         private Integer projectId;
         private Integer presetId;
         private Integer engineConfigurationId;
+        private Integer postScanActionId;
 
         CxScanSettingsBuilder() {
         }
@@ -79,8 +93,13 @@ public class CxScanSettings {
             return this;
         }
 
+        public CxScanSettings.CxScanSettingsBuilder postScanActionId(Integer postScanActionId) {
+            this.postScanActionId = postScanActionId;
+            return this;
+        }
+
         public CxScanSettings build() {
-            return new CxScanSettings(projectId, presetId, engineConfigurationId);
+            return new CxScanSettings(projectId, presetId, engineConfigurationId, postScanActionId);
         }
 
         public String toString() {

--- a/src/main/java/com/checkmarx/sdk/service/CxClient.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxClient.java
@@ -217,7 +217,7 @@ public interface CxClient {
      * @param engineConfigId
      * @return
      */
-    public Integer createScanSetting(Integer projectId, Integer presetId, Integer engineConfigId);
+    public Integer createScanSetting(Integer projectId, Integer presetId, Integer engineConfigId, Integer postBackId);
 
     /**
      * Get Scan Settings for an existing project (JSON String)

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -1172,8 +1172,8 @@ public class CxService implements CxClient{
      *
      * @return Scan setting ID.
      */
-    public Integer createScanSetting(Integer projectId, Integer presetId, Integer engineConfigId) {
-        return scanSettingsClient.createScanSettings(projectId, presetId, engineConfigId);
+    public Integer createScanSetting(Integer projectId, Integer presetId, Integer engineConfigId, Integer postActionId) {
+        return scanSettingsClient.createScanSettings(projectId, presetId, engineConfigId, postActionId);
     }
 
     /**
@@ -1639,7 +1639,6 @@ public class CxService implements CxClient{
         validateScanParams(params);
         String teamId = determineTeamId(params);
         Integer projectId = determineProjectId(params, teamId);
-
         boolean projectExistedBeforeScan = !projectId.equals(UNKNOWN_INT);
         if (!projectExistedBeforeScan) {
             projectId = createProject(teamId, params.getProjectName());
@@ -1647,11 +1646,9 @@ public class CxService implements CxClient{
                 throw new CheckmarxException("Project was not created successfully: ".concat(params.getProjectName()));
             }
         }
-
         Integer presetId = getPresetId(params.getScanPreset());
         Integer engineConfigurationId = getScanConfiguration(params.getScanConfiguration());
-        createScanSetting(projectId, presetId, engineConfigurationId);
-
+        createScanSetting(projectId, presetId, engineConfigurationId, cxProperties.getPostActionPostbackId());
         switch (params.getSourceType()) {
             case GIT:
                 setProjectRepositoryDetails(projectId, params.getGitUrl(), params.getBranch());

--- a/src/main/java/com/checkmarx/sdk/service/ScanSettingsClient.java
+++ b/src/main/java/com/checkmarx/sdk/service/ScanSettingsClient.java
@@ -9,7 +9,7 @@ import com.checkmarx.sdk.exception.CheckmarxException;
  * - scan presets
  */
 public interface ScanSettingsClient {
-    int createScanSettings(int projectId, int presetId, int engineConfigId);
+    int createScanSettings(int projectId, int presetId, int engineConfigId, int postScanId);
 
     String getScanSettings(int projectId);
 

--- a/src/main/java/com/checkmarx/sdk/service/ScanSettingsClientImpl.java
+++ b/src/main/java/com/checkmarx/sdk/service/ScanSettingsClientImpl.java
@@ -54,12 +54,14 @@ public class ScanSettingsClientImpl implements ScanSettingsClient {
     }
 
     @Override
-    public int createScanSettings(int projectId, int presetId, int engineConfigId) {
+    public int createScanSettings(int projectId, int presetId, int engineConfigId, int postActionId) {
         CxScanSettings scanSettings = CxScanSettings.builder()
                 .projectId(projectId)
                 .engineConfigurationId(engineConfigId)
                 .presetId(presetId)
                 .build();
+        if(cxProperties.getEnablePostActionMonitor() && postActionId != 0)
+            scanSettings.setPostScanActionId(postActionId);
         HttpEntity<CxScanSettings> requestEntity = new HttpEntity<>(scanSettings, authClient.createAuthHeaders());
 
         log.info("Creating ScanSettings for project Id {}", projectId);

--- a/src/main/resources/postback-action/cxflow.bat
+++ b/src/main/resources/postback-action/cxflow.bat
@@ -1,0 +1,2 @@
+cd "%~dp0"
+powershell ".\cxflow.ps1" '%1' '%2' '%3'

--- a/src/main/resources/postback-action/cxflow.ps1
+++ b/src/main/resources/postback-action/cxflow.ps1
@@ -1,0 +1,11 @@
+$resultsFile = $args[0]
+$resultsFile >> $logFile
+$token = $args[1]
+$cxURL = $args[2]
+[xml]$report = Get-Content -Path $resultsFile
+$body = @{
+    token = $token
+    scanComments = $report.CxXMLResults.scanComments
+}
+$cxURL += "/" + $report.CxXMLResults.ScanId
+Invoke-RestMethod -Method 'Post' -Uri $cxURL -Body $body


### PR DESCRIPTION
When CxFlow is running in post-back mode poIing will be turned off and CxFlow will be switched to an event driven mode. CxFlow will wait for the manager to post a response when the scan is complete. This is an optional mode of operation enabled by setting enable-post-action-monitor to true in the application config file, the default is to use the traditional poling mode.