### PR TITLE
Fix project settings override

### DIFF
--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -37,6 +37,7 @@ public class CxProperties extends CxPropertiesBase{
     private Integer codeSnippetLength = 2500;
     private Integer postActionPostbackId = 0;
 
+    private Boolean settingsOverride = false;
 
     private String portalPackage = "checkmarx.wsdl.portal";
 
@@ -212,5 +213,12 @@ public class CxProperties extends CxPropertiesBase{
         return this.postActionPostbackId;
     }
 
+    public Boolean getSettingsOverride() {
+        return settingsOverride;
+    }
+
+    public void setSettingsOverride(Boolean settingsOverride) {
+        this.settingsOverride = settingsOverride;
+    }
 }
 

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -1579,9 +1579,12 @@ public class CxService implements CxClient{
                 throw new CheckmarxException("Project was not created successfully: ".concat(params.getProjectName()));
             }
         }
-        Integer presetId = getPresetId(params.getScanPreset());
-        Integer engineConfigurationId = getScanConfiguration(params.getScanConfiguration());
-        createScanSetting(projectId, presetId, engineConfigurationId, cxProperties.getPostActionPostbackId());
+        if (!projectExistedBeforeScan || cxProperties.getSettingsOverride()) {
+            Integer presetId = getPresetId(params.getScanPreset());
+            Integer engineConfigurationId = getScanConfiguration(params.getScanConfiguration());
+            createScanSetting(projectId, presetId, engineConfigurationId, cxProperties.getPostActionPostbackId());
+            setProjectExcludeDetails(projectId, params.getFolderExclude(), params.getFileExclude());
+        }
         switch (params.getSourceType()) {
             case GIT:
                 setProjectRepositoryDetails(projectId, params.getGitUrl(), params.getBranch());
@@ -1606,7 +1609,6 @@ public class CxService implements CxClient{
             params.setIncremental(false);
         }
 
-        setProjectExcludeDetails(projectId, params.getFolderExclude(), params.getFileExclude());
         CxScan scan = CxScan.builder()
                 .projectId(projectId)
                 .isIncremental(params.isIncremental())


### PR DESCRIPTION
Update logic to only create/update scan settings and file exclusions on initial project creation or if the settings-override is set to true (default is false).  This logic will allow us to avoid using new 9.3 API

```
checkmarx
  ...
  settings-override: true #default false if not provided
```