### PR TITLE
ShardManager fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.4.64</version>
+	<version>0.4.65</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/ShardManager/ShardManagerHTTPInterceptor.java
+++ b/src/main/java/com/checkmarx/sdk/ShardManager/ShardManagerHTTPInterceptor.java
@@ -14,15 +14,11 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.support.HttpRequestWrapper;
 import java.io.IOException;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class ShardManagerHTTPInterceptor implements ClientHttpRequestInterceptor {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(ShardManagerHTTPInterceptor.class);
@@ -46,7 +42,7 @@ public class ShardManagerHTTPInterceptor implements ClientHttpRequestInterceptor
             ClientHttpRequestExecution execution) throws IOException {
         ShardSession shard = sessionTracker.getShardSession();
         if (!shard.getShardFound() && request.getURI().getPath().equals(authReq)) {
-            runShardManager(sessionTracker.getScanRequestID(), shard);
+            runShardManager(shard);
             body = overrideCredentials(request, body, shard);
             ClientHttpResponse clientResp = execution.execute(new ShardRequestWrapper(request, shard.getUrl()), body);
             return clientResp;
@@ -91,7 +87,7 @@ public class ShardManagerHTTPInterceptor implements ClientHttpRequestInterceptor
         }
     }
 
-    public void runShardManager(String scanID, ShardSession shard) {
+    public void runShardManager(ShardSession shard) {
         Binding bindings = new Binding();
         bindings.setProperty("shardProperties", shardProperties);
         bindings.setProperty("cxFlowLog", log);

--- a/src/main/resources/shard-manager/ShardManager.groovy
+++ b/src/main/resources/shard-manager/ShardManager.groovy
@@ -19,28 +19,34 @@ cxFlowLog.info("Number of Shards to scan ${shards.size()}")
 /// Start by checking if this team was already assigned to a shard
 //
 shards.eachWithIndex { shard, i ->
-    cxFlowLog.info("\tExamining shardName: ${shard.name}, teamLimit: ${shard.teamLimit}, projectLimit: ${shard.projectLimit}")
+    cxFlowLog.info("\tExamining shardName: ${shard.name}, teamLimit: ${shard.teamLimit}, projectLimit: ${shard.projectLimit}, projectCnt: ${shard.projectCnt}, teamCnt: ${shard.teamCnt}")
     if (shard.isDisabled == 0) {
         shard.shardProjects.each { project ->
-            cxFlowLog.info("\t\tFound assigned Project: ${project.projectName} for Team: ${project.teamName}")
+            // I stopped showing currently assigned projects because it too verbos
+            //cxFlowLog.info("\t\tFound assigned Project: ${project.projectName} for Team: ${project.teamName}")
             if (project.teamName == teamName && project.projectName == projectName) {
-                cxFlowLog.info("\t\t\tMatched project with exiting shard!")
+                cxFlowLog.info("\t\t\tMatched project with exiting shard, we're done!")
                 shardFound = true
                 projectShard = shard
-            }
-            // Keep track of first shard associated with the team with a free project slot, just in
-            // case we need it later.
-            if (project.teamName == teamName && shard.projectCnt < shard.projectLimit && availableShardForTeam == null) {
-                cxFlowLog.info("\t\t\tFound team shard with available project slot.")
-                availableShardForTeam = shard
-            }
-            // Is the shard not assigned to the team but also has a free team and project slot?
-            if (project.teamName != teamName && shard.teamCnt < shard.teamLimit && shard.projectCnt < shard.projectLimit && availableShard == null) {
-                cxFlowLog.info("\t\t\tFound shard with available team and project slot.")
-                availableShard = shard
+            } else {
+                // Keep track of first shard associated with the team with a free project slot, just in
+                // case we need it later.
+                if (project.teamName == teamName &&
+                        shard.projectCnt < shard.projectLimit &&
+                        availableShardForTeam == null) {
+                    cxFlowLog.info("\t\t\tFound team shard with available project slot.")
+                    availableShardForTeam = shard
+                }
+                // Is the shard not assigned to the team but also has a free team and project slot?
+                if (project.teamName != teamName &&
+                        shard.teamCnt < shard.teamLimit &&
+                        shard.projectCnt < shard.projectLimit &&
+                        availableShard == null) {
+                    cxFlowLog.info("\t\t\tFound shard with available team and project slot.")
+                    availableShard = shard
+                }
             }
         }
-        cxFlowLog.info("\tprojectCnt: ${shard.projectCnt}, teamCnt: ${shard.teamCnt}")
         // Is shard completely empty?
         if (shard.projectCnt == 0 && shard.teamCnt == 0 && emptyShard == null) {
             cxFlowLog.info("\t\t\tFound empty shard.")
@@ -55,29 +61,53 @@ shards.eachWithIndex { shard, i ->
 /// theres a shard with another team assigned.
 //
 if (!shardFound) {
-    cxFlowLog.info("\tExisting project shard not found.")
+    cxFlowLog.info("\tExisting project shard not found, trying to find available shard.")
     if (availableShardForTeam != null) {
         cxFlowLog.info("\t\tUsing shard with with current team attached.")
         projectShard = availableShardForTeam
-        projectShard.projectCnt++
+        cxFlowLog.info("Updating shard tracking information.")
+        dbTools.incShardProjectCnt(conn, projectShard)
+        dbTools.addShardProject(conn, projectShard.id, projectName, teamName)
     } else if (emptyShard != null) {
         cxFlowLog.info("\t\tUsing empty shard without existing teams or projects.")
         projectShard = emptyShard
-        projectShard.projectCnt++
-        projectShard.teamCnt++
+        cxFlowLog.info("Updating shard tracking information.")
+        dbTools.incShardProjectCnt(conn, projectShard)
+        dbTools.incShardTeamCnt(conn, projectShard)
+        dbTools.addShardProject(conn, projectShard.id, projectName, teamName)
     } else if (availableShard) {
         cxFlowLog.info("\t\tUsing shard other teams.")
         projectShard = availableShard
-        projectShard.projectCnt++
-        projectShard.teamCnt++
+        cxFlowLog.info("Updating shard tracking information.")
+        dbTools.incShardProjectCnt(conn, projectShard)
+        dbTools.incShardTeamCnt(conn, projectShard)
+        dbTools.addShardProject(conn, projectShard.id, projectName, teamName)
     } else {
-        cxFlowLog.info("\t\tERROR, Could not find shard for project!.")
+        cxFlowLog.info("\t\tERROR, All shards are out of project slots. This should be corrected but falling back to round robbin mode until it is.")
+        shards.eachWithIndex { shard, i ->
+            if (shard.isDisabled == 0) {
+                if(projectShard == null) {
+                    projectShard = shard
+                } else if(shard.projectCnt < projectShard.projectCnt) {
+                    projectShard = shard
+                }
+            }
+        }
+        // OK, lets update the project shard for whatever one that was picked.
+        cxFlowLog.info("Updating shard tracking information.")
+        dbTools.incShardProjectCnt(conn, projectShard)
+        // Check if the team is already on the project
+        def teamFound = false
+        projectShard.shardProjects.each { project ->
+            if (project.teamName == teamName) {
+                teamFound = true
+            }
+        }
+        if (!teamFound) {
+            dbTools.incShardTeamCnt(conn, projectShard)
+        }
+        dbTools.addShardProject(conn, projectShard.id, projectName, teamName)
     }
-    cxFlowLog.info("Updating shard tracking information.")
-    dbTools.addShardProject(conn, projectShard.id, projectName, teamName)
-    println("DONE ADDING SHARD")
-    dbTools.updateShard(conn, projectShard)
-    println("DONE UPDATING CNT INFO")
 }
 //
 /// Now know the shard to work with. Simply send its URL back to the client

--- a/src/main/resources/shard-manager/dbtools.groovy
+++ b/src/main/resources/shard-manager/dbtools.groovy
@@ -88,20 +88,6 @@ def addShardProject(conn, shardID, projectName, teamName) {
     stmt.close()
 }
 
-def updateShardProject(conn, sp) {
-    cxFlowLog.info("Updating shard project for project ${sp.project_name} and team ${sp.team_name}")
-    String updateShardProjectQry = """        
-        UPDATE shard_to_project SET
-            project_name = '${sp.project_name}',
-            team_name = '${sp.team_name}'            
-        WHERE
-            id = ${sp.id}
-    """
-    def stmt = conn.createStatement()
-    stmt.execute(updateShardProjectQry)
-    stmt.close()
-}
-
 def getShardProjects(conn, shardId) {
     String getShardProjectQry = """
         SELECT * FROM shard_to_project WHERE shard_id=${shardId}
@@ -122,18 +108,26 @@ def getShardProjects(conn, shardId) {
     return shardProjects
 }
 
-def updateShard(conn, shard) {
-    cxFlowLog.info("Updating shard ${shard.name}")
-    String updateShardQry = """        
-        UPDATE shard SET
-            project_cnt = ${shard.projectCnt},
-            team_cnt = ${shard.teamCnt}
-        WHERE
-            id = ${shard.id}
-    """
-    def stmt = conn.createStatement()
-    stmt.execute(updateShardQry)
-    stmt.close()
+def incShardProjectCnt(conn, shard) {
+    cxFlowLog.info("Incrementing shard project count for: ${shard.name}")
+    /*
+    def stmt = conn.prepareCall("call inc_shard_project_cnt(?)");
+    stmt.setInt(1, shard.id);
+    stmt.execute();
+    stmt.close();
+    */
+    def stmt = conn.prepareStatement("call inc_shard_project_cnt(?)");
+    stmt.setInt(1, shard.id);
+    stmt.execute();
+    stmt.close();
+}
+
+def incShardTeamCnt(conn, shard) {
+    cxFlowLog.info("Incrementing shard team count for: ${shard.name}")
+    def stmt = conn.prepareStatement("call inc_shard_team_cnt(?)");
+    stmt.setInt(1, shard.id);
+    stmt.execute();
+    stmt.close();
 }
 
 def getShardList(conn) {
@@ -184,3 +178,4 @@ class ShardProject {
     String projectName = ""
     String teamName = ""
 }
+


### PR DESCRIPTION
This is a fix for two race conditions in Shard Manager. These changes should not affect code that do not use Shard Manager.

The first race condition occurred due to the way Shard Manager was reading the scan ID associated with the the current job. The scan ID was being determined by intercepting system console logs, this worked most of the time but in about 5% of the situations an improper scan ID would be fetched from the log. The new version is much simpler and tracks the scan ID through the Log4j mechanism CxFlow uses. 

There was a second race condition that occurred when the Groovy scripts tried to update project and team counts in the database. The previous code us SQL to make the updates and it was possible for two transactions to interfere with each other. The new version uses atomic stored procedures to complete the update actions. The update requires the stored procedures to be created in the Postgres database engine and the documentation for that is in the Shard Manager section of the CxFlow wiki. The database updates are currently only valid for Postgres and will need to be ported to SQL Server and MySQL if required.