### PR TITLE
Support SCA scan with cxorigin header as 'CxFlow'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-  <version>0.4.76</version>
+  <version>0.4.77</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -14,6 +14,8 @@ import com.checkmarx.sdk.exception.CheckmarxException;
 import com.checkmarx.sdk.exception.InvalidCredentialsException;
 import com.checkmarx.sdk.service.scanner.CxClient;
 import com.checkmarx.sdk.utils.ScanUtils;
+import com.checkmarx.sdk.utils.scanner.client.ScanClientHelper;
+import com.checkmarx.sdk.utils.scanner.client.httpClient.CxHttpClient;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
@@ -1652,7 +1654,7 @@ public class CxService implements CxClient {
                 .build();
 
         HttpHeaders headers = authClient.createAuthHeaders();
-        headers.add("cxOrigin","CxFlow");
+        headers.add(CxHttpClient.ORIGIN_HEADER, ScanClientHelper.CX_FLOW_SCAN_ORIGIN_NAME);
         HttpEntity<CxScan> requestEntity = new HttpEntity<>(scan, headers);
 
         log.info("Creating Scan for project Id {}", projectId);

--- a/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
+++ b/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
@@ -106,6 +106,7 @@ public class ScaClientHelper extends ScanClientHelper implements IScanClientHelp
         // Pass tenant name in a custom header. This will allow to get token from on-premise access control server
         // and then use this token for SCA authentication in cloud.
         httpClient.addCustomHeader(TENANT_HEADER_NAME, config.getAstScaConfig().getTenant());
+        httpClient.addCustomHeader(CxHttpClient.ORIGIN_HEADER, ScanClientHelper.CX_FLOW_SCAN_ORIGIN_NAME);
     }
 
     @Override

--- a/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScanClientHelper.java
+++ b/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScanClientHelper.java
@@ -43,6 +43,7 @@ public abstract class ScanClientHelper {
     public static final String GET_SCAN ="/api/scans/%s";
     public static final String CREATE_SCAN = "/api/scans";
     public static final String GET_UPLOAD_URL = "/api/uploads";
+    public static final String CX_FLOW_SCAN_ORIGIN_NAME = "CxFlow";
 
     public ScanClientHelper(RestClientConfig config, Logger log) {
         validate(config, log);


### PR DESCRIPTION
Was tested both for GitUrl & Zip scans and was validated with Fadi from SCA that the new header with 'CxFlow' value received 