### PR TITLE
SCA -  Add flag to pass the entire source code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-  <version>0.4.84</version>
+  <version>0.4.85</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/config/RestClientConfig.java
+++ b/src/main/java/com/checkmarx/sdk/config/RestClientConfig.java
@@ -25,7 +25,8 @@ public class RestClientConfig  {
     private String teamId;
     private TokenLoginResponse token;
     private File zipFile;
-    
+    private boolean clonedRepo = false;
+
     private Integer progressInterval;
     private ScaConfig scaConfig;
     private AstConfig astConfig;

--- a/src/main/java/com/checkmarx/sdk/config/ScaConfig.java
+++ b/src/main/java/com/checkmarx/sdk/config/ScaConfig.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -26,6 +27,8 @@ public class ScaConfig {
     private String apiUrl;
     private String accessControlUrl;
     private String tenant;
+    private boolean includeSources;
+    private List<String> excludeFiles;
 
     @Optional
     private Map<Severity, Integer> thresholdsSeverity;

--- a/src/main/java/com/checkmarx/sdk/config/ScaProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/ScaProperties.java
@@ -30,4 +30,5 @@ public class ScaProperties {
     private String password;
     private boolean enabledZipScan;
     private String teamForNewProjects;
+    private boolean includeSources;
 }

--- a/src/main/java/com/checkmarx/sdk/dto/sca/Sca.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/Sca.java
@@ -34,5 +34,7 @@ public class Sca implements Serializable {
     protected List<String> filterSeverity;
     @JsonProperty
     protected Double filterScore;
+    @JsonProperty
+    protected boolean includeSources;
 
 }

--- a/src/main/java/com/checkmarx/sdk/dto/sca/ScaConfig.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/ScaConfig.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.io.Serializable;
+import java.util.List;
 
 @Getter
 @Setter
@@ -21,6 +22,8 @@ public class ScaConfig extends ScanConfigBase implements Serializable {
      * code to be uploaded into the cloud.
      */
     private boolean includeSources;
+
+    private List<String> excludeFiles;
     
     private String fingerprintsIncludePattern;
     private String manifestsIncludePattern;

--- a/src/main/java/com/checkmarx/sdk/service/scanner/ScaScanner.java
+++ b/src/main/java/com/checkmarx/sdk/service/scanner/ScaScanner.java
@@ -119,7 +119,9 @@ public class ScaScanner extends AbstractScanner {
 
         ScaConfig scaConfig = getScaSpecificConfig(scanParams);
         setSourceLocation(scanParams, restClientConfig, scaConfig);
-
+        if(scanParams.getRemoteRepoUrl() != null){
+            restClientConfig.setClonedRepo(true);
+        }
         restClientConfig.setScaConfig(scaConfig);
 
         return restClientConfig;
@@ -133,13 +135,14 @@ public class ScaScanner extends AbstractScanner {
             commonClientScaConfig.setApiUrl(sdkScaConfig.getApiUrl());
             commonClientScaConfig.setAccessControlUrl(sdkScaConfig.getAccessControlUrl());
             commonClientScaConfig.setTenant(sdkScaConfig.getTenant());
+            commonClientScaConfig.setIncludeSources(sdkScaConfig.isIncludeSources());
+            commonClientScaConfig.setExcludeFiles(sdkScaConfig.getExcludeFiles());
             commonClientScaConfig.setUsername(scaProperties.getUsername());
             commonClientScaConfig.setPassword(scaProperties.getPassword());
 
             String zipPath = scanParams.getZipPath();
             if (StringUtils.isNotEmpty(zipPath)) {
                 commonClientScaConfig.setZipFilePath(zipPath);
-                commonClientScaConfig.setIncludeSources(true);
             }
 
         } else {

--- a/src/main/java/com/checkmarx/sdk/utils/scanner/client/AstClientHelper.java
+++ b/src/main/java/com/checkmarx/sdk/utils/scanner/client/AstClientHelper.java
@@ -143,7 +143,8 @@ public class AstClientHelper extends ScanClientHelper implements IScanClientHelp
                 response = submitSourcesFromRemoteRepo(astConfig, config.getProjectName());
             } else {
 
-                response = submitAllSourcesFromLocalDir(config.getProjectName(), astConfig.getZipFilePath());
+                response = submitAllSourcesFromLocalDir(config.getProjectName()
+                );
             }
             scanId = extractScanIdFrom(response);
             astResults.setScanId(scanId);
@@ -155,14 +156,14 @@ public class AstClientHelper extends ScanClientHelper implements IScanClientHelp
         return astResults;
     }
 
-    protected HttpResponse submitAllSourcesFromLocalDir(String projectId, String zipFilePath) throws IOException {
+    protected HttpResponse submitAllSourcesFromLocalDir(String projectId) throws IOException {
         log.info("Using local directory flow.");
 
         PathFilter filter = new PathFilter("", "", log);
         String sourceDir = config.getSourceDir();
         byte[] zipFile = CxZipUtils.getZippedSources(config, filter, sourceDir, log);
 
-        return initiateScanForUpload(projectId, zipFile, zipFilePath);
+        return initiateScanForUpload(projectId, zipFile);
     }
 
     @Override

--- a/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScanClientHelper.java
+++ b/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScanClientHelper.java
@@ -56,7 +56,7 @@ public abstract class ScanClientHelper {
 
     protected abstract HandlerRef getBranchToScan(RemoteRepositoryInfo repoInfo);
 
-    protected abstract HttpResponse submitAllSourcesFromLocalDir(String projectId, String zipFilePath) throws IOException;
+    protected abstract HttpResponse submitAllSourcesFromLocalDir(String projectId) throws IOException;
 
     protected abstract String getWebReportPath() throws UnsupportedEncodingException;
 
@@ -227,7 +227,7 @@ public abstract class ScanClientHelper {
         results.setException(new ScannerRuntimeException(message, e));
     }
 
-    protected HttpResponse initiateScanForUpload(String projectId, byte[] zipFile, String zipFilePath) throws IOException {
+    protected HttpResponse initiateScanForUpload(String projectId, byte[] zipFile) throws IOException {
         String uploadedArchiveUrl = getSourcesUploadUrl();
         String cleanPath = uploadedArchiveUrl.split("\\?")[0];
         log.info("Uploading to: {}", cleanPath);


### PR DESCRIPTION
Enable user option to send a scan request to SCA including project sources or not.
Changes made in order to support all options once working locally with exclude files present 