### PR TITLE
Fixed: severity filter uses vulnerability severity instead of finding severity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-  <version>0.4.91</version>
+  <version>0.4.92</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>
@@ -40,11 +40,6 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
 			<version>1.20</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.5.11</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/src/main/java/com/checkmarx/sdk/service/FilterInputFactory.java
+++ b/src/main/java/com/checkmarx/sdk/service/FilterInputFactory.java
@@ -44,7 +44,7 @@ public class FilterInputFactory {
                 .id(finding.getNodeId())
                 .category(findingGroup.getName().toUpperCase(Locale.ROOT))
                 .cwe(findingGroup.getCweId())
-                .severity(findingGroup.getSeverity().toUpperCase(Locale.ROOT))
+                .severity(finding.getSeverity().toUpperCase(Locale.ROOT))
                 .status(finding.getStatus().toUpperCase(Locale.ROOT))
                 .state(stateName)
                 .build();


### PR DESCRIPTION
By default, finding severity is the same as the severity of its vulnerability type. However, users are able to override severity for a specific finding.

Before the fix, filtering logic used the severity of vulnerability type. This could lead to incorrect results if a user overrode severity for specific findings.

Work item: [531](https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/531/).

The tests are in CxFlow.