### PR TITLE
Support custom result states

### DIFF
--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -1,9 +1,14 @@
 package com.checkmarx.sdk.config;
 
 import com.checkmarx.sdk.utils.ScanUtils;
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.commons.collections4.MapUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
+
+import java.util.Map;
 
 import javax.annotation.PostConstruct;
 
@@ -44,6 +49,18 @@ public class CxProperties extends CxPropertiesBase{
     private String htmlStrip = "<style>.cxtaghighlight{color: rgb(101, 170, 235);font-weight:bold;}</style>";
 
     private Boolean enabledZipScan = false;
+
+    private Map<String, String> customStateMap;
+
+    /**
+     * Maps finding state ID (as returned in CxSAST report) to state name (as specified in filter configuration).
+     */
+    private static final Map<String, String> CXSAST_STATE_ID_TO_NAME = ImmutableMap.of(
+            "0", "TO VERIFY",
+            "2", "CONFIRMED",
+            "3", "URGENT",
+            "4", "PROPOSED NOT EXPLOITABLE"
+    );
 
     public void setEnabledZipScan(Boolean enabledZipScan){
         this.enabledZipScan = enabledZipScan;
@@ -229,6 +246,18 @@ public class CxProperties extends CxPropertiesBase{
 
     public void setSettingsOverride(Boolean settingsOverride) {
         this.settingsOverride = settingsOverride;
+    }
+
+    public void setCustomStateMap(Map<String, String> customStateMap) {
+	this.customStateMap = customStateMap;
+    }
+
+    public String getStateFullName(String key){
+	String stateFullName = CXSAST_STATE_ID_TO_NAME.get(key);
+	if (stateFullName == null && customStateMap != null) {
+	    stateFullName = customStateMap.get(key);
+	}
+	return stateFullName;
     }
 }
 

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -763,7 +763,7 @@ public class CxService implements CxClient {
                         xIssueBuilder.file(resultType.getFileName());
                         xIssueBuilder.severity(resultType.getSeverity());
                         xIssueBuilder.link(resultType.getDeepLink());
-                        xIssueBuilder.vulnerabilityStatus(getStateFullName(resultType.getState()));
+                        xIssueBuilder.vulnerabilityStatus(cxProperties.getStateFullName(resultType.getState()));
                         xIssueBuilder.queryId(result.getId());
 
  
@@ -808,10 +808,6 @@ public class CxService implements CxClient {
                 }
         }
         return summary;
-    }
-
-    public String getStateFullName(String key){
-        return cxProperties.getStateFullName(key);
     }
     
     private Map<String, Object> getAdditionalIssueDetails(QueryType q, ResultType r) {

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -81,12 +81,6 @@ public class CxService implements CxClient {
     Created (2)
     */
     public static final Integer REPORT_STATUS_CREATED = 2;
-    private static final Map<String, Integer> STATE_MAP = ImmutableMap.of(
-            "TO VERIFY", 0,
-            "CONFIRMED", 2,
-            "URGENT", 3,
-            "PROPOSED NOT EXPLOITABLE",4
-    );
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(CxService.class);
     private static final String CUSTOM_FIELDS = "/customFields";
     private static final String TEAMS = "/auth/teams";
@@ -817,7 +811,7 @@ public class CxService implements CxClient {
     }
 
     public String getStateFullName(String key){
-        return ((Map<Integer, String>)MapUtils.invertMap(STATE_MAP)).get(Integer.parseInt(key));
+        return cxProperties.getStateFullName(key);
     }
     
     private Map<String, Object> getAdditionalIssueDetails(QueryType q, ResultType r) {

--- a/src/main/java/com/checkmarx/sdk/service/FilterInputFactory.java
+++ b/src/main/java/com/checkmarx/sdk/service/FilterInputFactory.java
@@ -1,5 +1,6 @@
 package com.checkmarx.sdk.service;
 
+import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.dto.cx.xml.QueryType;
 import com.checkmarx.sdk.dto.cx.xml.ResultType;
 import com.checkmarx.sdk.dto.cxgo.OdScanResultItem;
@@ -23,22 +24,19 @@ import java.util.stream.Collectors;
 @Service
 @Slf4j
 public class FilterInputFactory {
-    /**
-     * Maps finding state ID (as returned in CxSAST report) to state name (as specified in filter configuration).
-     */
-    private static final Map<String, String> CXSAST_STATE_ID_TO_NAME = ImmutableMap.of(
-            "0", "TO VERIFY",
-            "2", "CONFIRMED",
-            "3", "URGENT",
-            "4", "PROPOSED NOT EXPLOITABLE"
-    );
+
+    private final CxProperties cxProperties;
+
+    public FilterInputFactory(CxProperties cxProperties) {
+	this.cxProperties = cxProperties;
+    }
 
     private static final Map<Integer, SASTScanResult.State> CXGO_STATE_ID_TO_NAME =
             Arrays.stream(SASTScanResult.State.values())
             .collect(Collectors.toMap(SASTScanResult.State::getValue, Function.identity()));
 
     public FilterInput createFilterInputForCxSast(QueryType findingGroup, ResultType finding) {
-        String stateName = CXSAST_STATE_ID_TO_NAME.get(finding.getState());
+        String stateName = cxProperties.getStateFullName(finding.getState());
 
         return FilterInput.builder()
                 .id(finding.getNodeId())

--- a/src/main/java/com/checkmarx/sdk/service/FilterInputFactory.java
+++ b/src/main/java/com/checkmarx/sdk/service/FilterInputFactory.java
@@ -9,6 +9,7 @@ import com.checkmarx.sdk.dto.cxgo.SCAScanResult;
 import com.checkmarx.sdk.dto.filtering.FilterInput;
 import com.checkmarx.sdk.dto.sca.report.Finding;
 import com.google.common.collect.ImmutableMap;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -23,13 +24,10 @@ import java.util.stream.Collectors;
  */
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class FilterInputFactory {
 
     private final CxProperties cxProperties;
-
-    public FilterInputFactory(CxProperties cxProperties) {
-	this.cxProperties = cxProperties;
-    }
 
     private static final Map<Integer, SASTScanResult.State> CXGO_STATE_ID_TO_NAME =
             Arrays.stream(SASTScanResult.State.values())

--- a/src/test/java/com/checkmarx/sdk/service/sast/FilterValidatorTest.java
+++ b/src/test/java/com/checkmarx/sdk/service/sast/FilterValidatorTest.java
@@ -1,5 +1,6 @@
 package com.checkmarx.sdk.service.sast;
 
+import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.dto.sast.Filter;
 import com.checkmarx.sdk.dto.cx.xml.QueryType;
 import com.checkmarx.sdk.dto.cx.xml.ResultType;
@@ -141,7 +142,7 @@ public class FilterValidatorTest {
         FilterValidator validator = new FilterValidator();
 
         try {
-            FilterInputFactory filterInputFactory = new FilterInputFactory();
+            FilterInputFactory filterInputFactory = new FilterInputFactory(new CxProperties());
             FilterInput filterInput = filterInputFactory.createFilterInputForCxSast(findingGroup, finding);
             validator.passesFilter(filterInput, filterConfiguration);
         } catch (Exception e) {
@@ -167,7 +168,7 @@ public class FilterValidatorTest {
         EngineFilterConfiguration filterConfiguration = createFilterConfiguration(script);
 
         FilterValidator validator = new FilterValidator();
-        FilterInputFactory filterInputFactory = new FilterInputFactory();
+        FilterInputFactory filterInputFactory = new FilterInputFactory(new CxProperties());
         FilterInput filterInput = filterInputFactory.createFilterInputForCxSast(findingGroup, finding);
         boolean actualResult = validator.passesFilter(filterInput, filterConfiguration);
         assertEquals(expectedResult, actualResult, "Unexpected script filtering result.");
@@ -187,7 +188,7 @@ public class FilterValidatorTest {
                 .simpleFilters(filters)
                 .build();
 
-        FilterInputFactory filterInputFactory = new FilterInputFactory();
+        FilterInputFactory filterInputFactory = new FilterInputFactory(new CxProperties());
         FilterInput filterInput = filterInputFactory.createFilterInputForCxSast(findingGroup, finding);
         boolean passes = filterValidator.passesFilter(filterInput, filterConfiguration);
         assertEquals(expectedResult, passes, "Unexpected simple filtering result.");

--- a/src/test/java/com/checkmarx/sdk/service/sca/ScaTest.java
+++ b/src/test/java/com/checkmarx/sdk/service/sca/ScaTest.java
@@ -220,7 +220,7 @@ public class ScaTest extends ScaTestsBase {
 
 
     private ScaScanner getScanner() {
-        return new ScaScanner(scaProperties, new FilterInputFactory(), new FilterValidator());
+        return new ScaScanner(scaProperties, new FilterInputFactory(new CxProperties()), new FilterValidator());
     }
 
     private ScanParams getScanParams(RestClientConfig config) {


### PR DESCRIPTION
Clients can now define custom result states by adding a checkmarx.customStateMap property to the SDk configuration.

This also removes the duplication of the mapping of OOTB states to their descriptions (previously, separate maps were found in the
CxService and FilterInputFactory classes.

This is something that has been requested by at least two clients, one that is currently using a customized version of the SDK, and another for which an issue was raised against CxFlow (https://github.com/checkmarx-ltd/cx-flow/issues/523).