### PR TITLE
Ignore case when comparing team names

### DIFF
--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -1347,7 +1347,7 @@ public class CxService implements CxClient {
                 throw new CheckmarxException("Error obtaining Team Id");
             }
             for (CxTeam team : teams) {
-                if (team.getFullName().equals(teamPath)) {
+                if (team.getFullName().equalsIgnoreCase(teamPath)) {
                     log.info(FOUND_TEAM, teamPath, team.getId());
                     return team.getId();
                 }


### PR DESCRIPTION
CxSAST will not allow the creation of two teams whose names differ only by case so it does not make sense to perform a case-sensitive comparison of team names.

Addresses issue #145.