### PR TITLE
Support grouping results by severity

### DIFF
--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -52,6 +52,11 @@ public class CxProperties extends CxPropertiesBase{
 
     private Map<String, String> customStateMap;
 
+    /*
+     * If set to true, group results by vulnerability, filename and
+     * severity (by default, results are grouped only by vulnerability
+     * and filename).
+     */
     private Boolean groupBySeverity = false;
 
     /**

--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -52,6 +52,8 @@ public class CxProperties extends CxPropertiesBase{
 
     private Map<String, String> customStateMap;
 
+    private Boolean groupBySeverity = false;
+
     /**
      * Maps finding state ID (as returned in CxSAST report) to state name (as specified in filter configuration).
      */
@@ -258,6 +260,14 @@ public class CxProperties extends CxPropertiesBase{
 	    stateFullName = customStateMap.get(key);
 	}
 	return stateFullName;
+    }
+
+    public Boolean getGroupBySeverity() {
+	return groupBySeverity;
+    }
+
+    public void setGroupBySeverity(Boolean groupBySeverity) {
+	this.groupBySeverity = groupBySeverity;
     }
 }
 

--- a/src/main/java/com/checkmarx/sdk/dto/ScanResults.java
+++ b/src/main/java/com/checkmarx/sdk/dto/ScanResults.java
@@ -257,12 +257,13 @@ public class ScanResults{
 
             XIssue issue = (XIssue) o;
 
-            if (!vulnerability.equals(issue.vulnerability)) return false;
+            if (!vulnerability.equals(issue.vulnerability)) {
+                return false;
+            }
             if (groupBySeverity) {
-        	if (!filename.equals(issue.filename)) return false;
-        	return severity.equals(issue.severity);
+                return filename.equals(issue.filename) && severity.equals(issue.severity);
             } else {
-        	return filename.equals(issue.filename);
+                return filename.equals(issue.filename);
             }
         }
 

--- a/src/main/java/com/checkmarx/sdk/dto/ScanResults.java
+++ b/src/main/java/com/checkmarx/sdk/dto/ScanResults.java
@@ -222,10 +222,11 @@ public class ScanResults{
         private Map<Integer, IssueDetails>  details;
         private Map<String, Object> additionalDetails;
         private String queryId;
+        private boolean groupBySeverity;
 
         XIssue(String vulnerability, String vulnerabilityStatus, String similarityId, String cwe, String cve, String description, String language,
                String severity, String link, String filename, String gitUrl, List<OsaDetails> osaDetails, List<ScaDetails> scaDetails, Map<Integer, IssueDetails> details,
-               Map<String, Object> additionalDetails, String queryId) {
+               Map<String, Object> additionalDetails, String queryId, boolean groupBySeverity) {
             this.vulnerability = vulnerability;
             this.vulnerabilityStatus = vulnerabilityStatus;
             this.similarityId = similarityId;
@@ -242,6 +243,7 @@ public class ScanResults{
             this.details = details;
             this.additionalDetails = additionalDetails;
             this.queryId = queryId;
+            this.groupBySeverity = groupBySeverity;
         }
 
         public static XIssueBuilder builder() {
@@ -256,7 +258,12 @@ public class ScanResults{
             XIssue issue = (XIssue) o;
 
             if (!vulnerability.equals(issue.vulnerability)) return false;
-            return filename.equals(issue.filename);
+            if (groupBySeverity) {
+        	if (!filename.equals(issue.filename)) return false;
+        	return severity.equals(issue.severity);
+            } else {
+        	return filename.equals(issue.filename);
+            }
         }
 
         @Override
@@ -265,6 +272,9 @@ public class ScanResults{
             if(vulnerability != null) {
                 result = vulnerability.hashCode();
                 result = HASH_CONST * result + filename.hashCode();
+                if (groupBySeverity) {
+                    result = HASH_CONST * result + severity.hashCode();
+                }
             }else{
                 if(scaDetails != null){
                     result = scaDetails.get(0).finding.hashCode();
@@ -425,6 +435,7 @@ public class ScanResults{
             private String link;
             private String file;
             private String queryId;
+            private Boolean groupBySeverity;
             private List<OsaDetails> osaDetails;
             private List<ScaDetails> scaDetails;
 
@@ -488,6 +499,11 @@ public class ScanResults{
                 return this;
             }
 
+            public XIssue.XIssueBuilder groupBySeverity(Boolean groupBySeverity) {
+                this.groupBySeverity = groupBySeverity;
+                return this;
+            }
+
             public XIssue.XIssueBuilder osaDetails(List<OsaDetails> osaDetails) {
                 this.osaDetails = osaDetails;
                 return this;
@@ -509,7 +525,7 @@ public class ScanResults{
             }
 
             public XIssue build() {
-                return new XIssue(vulnerability,  vulnerabilityStatus, similarityId, cwe, cve, description, language, severity, link, file, "", osaDetails, scaDetails, details, additionalDetails, queryId);
+                return new XIssue(vulnerability,  vulnerabilityStatus, similarityId, cwe, cve, description, language, severity, link, file, "", osaDetails, scaDetails, details, additionalDetails, queryId, groupBySeverity);
             }
 
             @Override

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -755,8 +755,6 @@ public class CxService implements CxClient {
                         if(!resultType.getFalsePositive().equalsIgnoreCase("FALSE")){
                             falsePositive = true;
                         }
-                        log.debug("getIssues: id: {}, severity: {}, result type filename: {}, result type severity: {}",
-                        	result.getId(), result.getSeverity(), resultType.getFileName(), resultType.getSeverity());
                         /*Map issue details*/
                         xIssueBuilder.cwe(result.getCweId());
                         xIssueBuilder.language(result.getLanguage());

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -755,6 +755,8 @@ public class CxService implements CxClient {
                         if(!resultType.getFalsePositive().equalsIgnoreCase("FALSE")){
                             falsePositive = true;
                         }
+                        log.debug("getIssues: id: {}, severity: {}, result type filename: {}, result type severity: {}",
+                        	result.getId(), result.getSeverity(), resultType.getFileName(), resultType.getSeverity());
                         /*Map issue details*/
                         xIssueBuilder.cwe(result.getCweId());
                         xIssueBuilder.language(result.getLanguage());
@@ -765,6 +767,7 @@ public class CxService implements CxClient {
                         xIssueBuilder.link(resultType.getDeepLink());
                         xIssueBuilder.vulnerabilityStatus(cxProperties.getStateFullName(resultType.getState()));
                         xIssueBuilder.queryId(result.getId());
+                        xIssueBuilder.groupBySeverity(cxProperties.getGroupBySeverity());
 
  
                         // Add additional details


### PR DESCRIPTION
By default, results are grouped by vulnerability and filename. This change allows the grouping to optionally also include the result
severity (i.e., two results for the same vulnerability in the same file but with different severities will be considered as two distinct results).

This is a reimplementation of a change made for Woolworths. The reimplementation makes the change in functionality configurable via the group-by-severity property in the application.yml file. If this property is not specified, the normal behavior is exhibited (grouping only by vulnerability and filename).

If this PR is accepted, I will create a separate one to update the CxFlow documentation accordingly.