### PR TITLE
ShardManager decoupled the post-back action from the post-back process

### DIFF
--- a/src/main/java/com/checkmarx/sdk/config/CxPropertiesBase.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxPropertiesBase.java
@@ -32,6 +32,7 @@ public abstract class CxPropertiesBase {
     private String projectScript;
     private Boolean enablePostActionMonitor = false;
     private String postCloneScript;
+    private Boolean enablePostActionEvent = false;
     
     public abstract Boolean getEnableOsa();
     
@@ -261,6 +262,14 @@ public abstract class CxPropertiesBase {
 
     public void setEnablePostActionMonitor(Boolean enablePostActionMonitor) {
         this.enablePostActionMonitor = enablePostActionMonitor;
+    }
+
+    public boolean getEnablePostActionEvent() {
+        return this.enablePostActionEvent;
+    }
+
+    public void setEnablePostActionEvent(Boolean enablePostActionEvent) {
+        this.enablePostActionEvent = enablePostActionEvent;
     }
 
     public String getPostCloneScript() {

--- a/src/main/java/com/checkmarx/sdk/service/ScanSettingsClientImpl.java
+++ b/src/main/java/com/checkmarx/sdk/service/ScanSettingsClientImpl.java
@@ -60,7 +60,7 @@ public class ScanSettingsClientImpl implements ScanSettingsClient {
                 .engineConfigurationId(engineConfigId)
                 .presetId(presetId)
                 .build();
-        if(cxProperties.getEnablePostActionMonitor() && postActionId != 0)
+        if(cxProperties.getEnablePostActionEvent() && postActionId != 0)
             scanSettings.setPostScanActionId(postActionId);
         HttpEntity<CxScanSettings> requestEntity = new HttpEntity<>(scanSettings, authClient.createAuthHeaders());
 

--- a/src/main/resources/shard-manager/CheckProject.groovy
+++ b/src/main/resources/shard-manager/CheckProject.groovy
@@ -1,0 +1,44 @@
+//@Grab(group='org.codehaus.groovy.modules.http-builder', module='http-builder', version='0.7' )
+//import groovyx.net.http.HTTPBuilder
+import com.checkmarx.flow.dto.ScanRequest
+import com.checkmarx.flow.utils.ScanUtils
+import groovy.json.JsonSlurper
+
+println("------------- Groovy script execution started --------------------")
+println("Checking 'request' object for details and determine if scan is applicable for this branch (target or current)")
+
+//define the custom list of protected branches to compare against the branch in request
+def protectedBranchList = ['agehring-.*','remediate-.*','security']
+
+String branch = request.getBranch();
+String targetBranch = request.getMergeTargetBranch();
+if(!ScanUtils.empty(targetBranch)) { //if targetBranch is set, it is a merge request
+    branch = targetBranch;
+}
+println("This is the branch from request: " + branch)
+def Boolean branchMatched = false;
+protectedBranchList.each { //iterate over each of the protected branches
+    if((it.toString()).equals(branch))
+    {
+       branchMatched = true;
+    }
+}
+println("Is branch valid for scan ?: "+ branchMatched)
+println("-------- Groovy script execution ended -------------")
+if(branchMatched) {
+    return true;
+}
+else
+{
+    return false
+};
+
+//for accessing the original payload
+String WEB_HOOK_PAYLOAD = "web-hook-payload";
+def payload = request.getAdditionalMetadata(WEB_HOOK_PAYLOAD)
+JsonSlurper jsonParser = new JsonSlurper()
+Map parsedJson =  jsonParser.parseText(payload)
+println(parsedJson.toString())
+
+//if you want to add something to the scanRequest object
+request.putAdditionalMetadata("moreData","Value");


### PR DESCRIPTION
This change allows ShardManager to users to use the post-back response without configuring the post-back action. The helps when the user wants to manually configure the post-back process in SAST. 