### PR TITLE
Resolving bug reported in https://github.com/checkmarx-ltd/cx-flow/issues/840

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
- 	<version>0.5.02</version>
+ 	<version>0.5.03</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
- 	<version>0.5.03</version>
+ 	<version>0.5.02</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -1042,7 +1042,7 @@ public class CxService implements CxClient {
             ResponseEntity<String> projects = restTemplate.exchange(cxProperties.getUrl().concat(PROJECTS)
                     .concat("?projectName=").concat(name).concat("&teamId=").concat(ownerId), HttpMethod.GET, httpEntity, String.class);
             JSONArray arr = new JSONArray(projects.getBody());
-            if (arr.length() > 1) {
+            if (arr.length() < 1) {
                 return UNKNOWN_INT;
             }
             JSONObject obj = arr.getJSONObject(0);


### PR DESCRIPTION
When `/cxrestapi/projects?projectName={projectName}&teamId={teamId}` is called and returns an empty array, CxFlow was returning the error reported at https://github.com/checkmarx-ltd/cx-flow/issues/840. 