### PR TITLE
added feature for exclude files from scan via CLI or webhook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
- 	<version>0.5.02</version>
+ 	<version>0.5.03</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/config/ScaConfig.java
+++ b/src/main/java/com/checkmarx/sdk/config/ScaConfig.java
@@ -31,6 +31,10 @@ public class ScaConfig {
     private boolean includeSources;
     @Optional
     private List<String> excludeFiles;
+    @Optional
+    private String fingerprintsIncludePattern;
+    @Optional
+    private String manifestsIncludePattern;
 
     @Optional
     private Map<Severity, Integer> thresholdsSeverity;

--- a/src/main/java/com/checkmarx/sdk/config/ScaProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/ScaProperties.java
@@ -32,4 +32,7 @@ public class ScaProperties {
     private String team;
     private boolean includeSources;
     private Integer scanTimeout;
+    private String excludeFiles;
+    private String fingerprintsIncludePattern;
+    private String manifestsIncludePattern;
 }

--- a/src/main/java/com/checkmarx/sdk/service/scanner/ScaScanner.java
+++ b/src/main/java/com/checkmarx/sdk/service/scanner/ScaScanner.java
@@ -139,6 +139,8 @@ public class ScaScanner extends AbstractScanner {
             scaConfig.setExcludeFiles(sdkScaConfig.getExcludeFiles());
             scaConfig.setUsername(scaProperties.getUsername());
             scaConfig.setPassword(scaProperties.getPassword());
+            scaConfig.setFingerprintsIncludePattern(scaProperties.getFingerprintsIncludePattern());
+            scaConfig.setManifestsIncludePattern(scaProperties.getManifestsIncludePattern());
             scaConfig.setTeam(sdkScaConfig.getTeam());
             scaConfig.setScanTimeout(sdkScaConfig.getScanTimeout());
             String zipPath = scanParams.getZipPath();

--- a/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
+++ b/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
@@ -305,7 +305,17 @@ public class ScaClientHelper extends ScanClientHelper implements IScanClientHelp
             zipFile = FileUtils.readFileToByteArray(new File(zipFilePath));
         } else {
             // CLI Mode
-            PathFilter filter = new PathFilter("", "", log);
+            // The Exclude files parameter is used as a regular expression but
+            // for this method it is used as include,exclude pattern which requires exclude files
+            // to begin with an ! to be then used by the directoryScanner used in this utility.
+            // So the below method converts the list to comma separated string and all elements starts with !.
+            String pattern = "";
+            for (String nextpattern: this.scaConfig.getExcludeFiles()) {
+                pattern += "!" + nextpattern + ",";
+            }
+            // removing the last comma from the string
+            pattern = pattern.substring(0,pattern.length()-1);
+            PathFilter filter = new PathFilter("", pattern, log);
             zipFile = CxZipUtils.getZippedSources(config, filter, sourceDir, log);
         }
 


### PR DESCRIPTION
> This PR adds the feature which allows user to exclude files from scanning with cli and webhook.

>Test Results

| enabled-zipped-scan:   false | enabled-zipped-scan : true     include-sources: true     exclude-files: "pom.xml, Dockerfile" | enabled-zipped-scan : true     include-sources: false     manifests-include-pattern: "**/pom.xml,   **/Dockerfile**"     fingerprints-include-pattern: "!.checkmarx/**, !**/*.yml" | enabled-zipped-scan : true     include-sources:   false     manifests-include-pattern: "**/pom.xml, !**/Dockerfile**"     fingerprints-include-pattern: "!.checkmarx/**, **/*.yml" | enabled-zipped-scan : true     include-sources:   false     manifests-include-pattern:      fingerprints-include-pattern: |
-- | -- | -- | -- | --
Used   the configuration from      server for the project | a.   scanParams->scaConfig->excludeFiles = [ pom.xml, Dockerfile]     	b. converted List of excludeFiles to String (, separated)     	c. created a zip folder excluding the pom.xml file and Dockerfile | a. zipped : pom.xml and   Dockerfile and .cxsca.sig     	b. excluded docker-compose.yml and .checkmarx/config.yaml files from   fingerprint calculation | a. zipped : pom.xml and   .cxsca.sig     b. included docker-compose.yml and .github/workflows/cx.yaml files in   fingerprint calculation | Got the manifest and fingerprint   patterns from SCA server and used it.
  | enabled-zipped-scan : true     include-sources: true     exclude-files: "pom.xml, Dockerfile" | enabled-zipped-scan : true     include-sources: false     manifests-include-pattern: "**/pom.xml,   **/Dockerfile**"     fingerprints-include-pattern: "!.checkmarx/**, !**/*.yml" | enabled-zipped-scan : true     include-sources:   false     manifests-include-pattern: "**/pom.xml, !**/Dockerfile**"     fingerprints-include-pattern: "!.checkmarx/**, **/*.yml" | enabled-zipped-scan : true     include-sources:   false     below params provided in cmd     manifests-include-pattern:     "**/pom.xml, !**/Dockerfile**"      fingerprints-include-pattern:     "!.checkmarx/**, **/*.yml"
  | Excluded pom.xml and Dockerfile | a. zipped : pom.xml and   Dockerfile and .cxsca.sig     	b. excluded docker-compose.yml and .checkmarx/config.yaml files from   fingerprint calculation | a. zipped : pom.xml and   .cxsca.sig     b. included docker-compose.yml and .github/workflows/cx.yaml files in   fingerprint calculation | a. zipped : pom.xml and   .cxsca.sig     b. included docker-compose.yml and .github/workflows/cx.yaml files in   fingerprint calculation |
 



