### PR TITLE
SCA ignored vulnerabilities are not processed correctly. Deny code upload is not handled.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
- 	<version>0.5.03</version>
+ 	<version>0.5.04</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/dto/ScanResults.java
+++ b/src/main/java/com/checkmarx/sdk/dto/ScanResults.java
@@ -306,10 +306,13 @@ public class ScanResults{
         }
 
         public boolean isAllFalsePositive(){
-            if(this.getDetails() == null){
-                return false;
-            }
-            return this.getDetails().size() <= this.getFalsePositiveCount();
+            
+            if(this.getDetails() != null) 
+            	return this.getDetails().size() <= this.getFalsePositiveCount();
+            else if(this.getScaDetails() != null)
+            	return this.getScaDetails().size() <=this.getFalsePositiveCount();
+            else
+            	return false;
         }
 
         public String getSimilarityId() {

--- a/src/main/java/com/checkmarx/sdk/dto/sca/CxSCAScanAPIConfig.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/CxSCAScanAPIConfig.java
@@ -1,0 +1,16 @@
+package com.checkmarx.sdk.dto.sca;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import com.checkmarx.sdk.dto.ScanConfigValue;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CxSCAScanAPIConfig implements ScanConfigValue {
+    private String includeSourceCode;
+}
+

--- a/src/main/java/com/checkmarx/sdk/dto/sca/ScaUploadUrlRequest.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/ScaUploadUrlRequest.java
@@ -1,0 +1,14 @@
+package com.checkmarx.sdk.dto.sca;
+
+import com.checkmarx.sdk.dto.ScanConfig;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class ScaUploadUrlRequest {
+
+    private List<ScanConfig> config;
+}

--- a/src/main/java/com/checkmarx/sdk/dto/sca/report/Finding.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/report/Finding.java
@@ -1,6 +1,8 @@
 package com.checkmarx.sdk.dto.sca.report;
 
 import com.checkmarx.sdk.dto.scansummary.Severity;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -26,5 +28,7 @@ public class Finding implements Serializable {
     private String packageId;
     private String similarityId;
     private String fixResolutionText;
+
+    @JsonProperty(value="isIgnored")
     private boolean isIgnored;
 }

--- a/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
+++ b/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
@@ -123,9 +123,15 @@ public class ScaClientHelper extends ScanClientHelper implements IScanClientHelp
 
     @Override
     protected ScanConfig getScanConfig() {
-        return ScanConfig.builder()
+    	
+    	CxSCAScanAPIConfig apiConfig = new CxSCAScanAPIConfig();
+    	apiConfig.setIncludeSourceCode(Boolean.toString(scaConfig.isIncludeSources()));
+    
+        ScanConfig scanConfig =  ScanConfig.builder()
                 .type(ENGINE_TYPE_FOR_API)
+                .value(apiConfig)
                 .build();
+        return scanConfig;
     }
 
     @Override
@@ -310,11 +316,14 @@ public class ScaClientHelper extends ScanClientHelper implements IScanClientHelp
             // to begin with an ! to be then used by the directoryScanner used in this utility.
             // So the below method converts the list to comma separated string and all elements starts with !.
             String pattern = "";
-            for (String nextpattern: this.scaConfig.getExcludeFiles()) {
-                pattern += "!" + nextpattern + ",";
+            if(this.scaConfig.getExcludeFiles() != null) {
+	            for (String nextpattern: this.scaConfig.getExcludeFiles()) {
+	                pattern += "!" + nextpattern + ",";
+	            }
+	            // removing the last comma from the string
+	            pattern = pattern.substring(0,pattern.length()-1);
             }
-            // removing the last comma from the string
-            pattern = pattern.substring(0,pattern.length()-1);
+
             PathFilter filter = new PathFilter("", pattern, log);
             zipFile = CxZipUtils.getZippedSources(config, filter, sourceDir, log);
         }

--- a/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScanClientHelper.java
+++ b/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScanClientHelper.java
@@ -1,25 +1,30 @@
 package com.checkmarx.sdk.utils.scanner.client;
 
 import com.checkmarx.sdk.dto.*;
+import com.checkmarx.sdk.dto.sca.ScaStartScanRequest;
+import com.checkmarx.sdk.dto.sca.ScaUploadUrlRequest;
 import com.checkmarx.sdk.exception.ScannerRuntimeException;
 import com.checkmarx.sdk.utils.ScanWaiter;
 import com.checkmarx.sdk.utils.State;
 import com.checkmarx.sdk.utils.UrlUtils;
+import com.checkmarx.sdk.config.ContentType;
 import com.checkmarx.sdk.config.RestClientConfig;
-import com.checkmarx.sdk.dto.ResultsBase;
-import com.checkmarx.sdk.dto.SourceLocationType;
 import com.checkmarx.sdk.utils.scanner.client.httpClient.CxHttpClient;
+import com.checkmarx.sdk.utils.scanner.client.httpClient.HttpClientHelper;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.entity.StringEntity;
 import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 public abstract class ScanClientHelper {
@@ -182,7 +187,12 @@ public abstract class ScanClientHelper {
     }
 
     private String getSourcesUploadUrl() throws IOException {
-        JsonNode response = httpClient.postRequest(GET_UPLOAD_URL, null, null, JsonNode.class,
+    	List<ScanConfig> apiScanConfig = Collections.singletonList(getScanConfig());
+        ScaUploadUrlRequest request = ScaUploadUrlRequest.builder()
+                .config(apiScanConfig)
+                .build();
+        StringEntity entity = HttpClientHelper.convertToStringEntity(request);
+        JsonNode response = httpClient.postRequest(GET_UPLOAD_URL, ContentType.CONTENT_TYPE_APPLICATION_JSON, entity, JsonNode.class,
                 HttpStatus.SC_OK, "get upload URL for sources");
 
         if (response == null || response.get("url") == null) {


### PR DESCRIPTION
This PR fixes below mentioned two issues.
Fixes AB#605 - Vulnerability triagged as ignored is still processed when JIRA as bug tracker. The JIRA issue gets updated instead of getting closed.

JiraService code is common for SAST and SCA vulnerabilities. False positive logic was implemented only for SAST. Fix is to add false positive logic for SCA as well.

Fixes AB#606 - When code upload is denied on SCA account, CxFlow fails to perform scan even with just manifest.

When sca.includeSources is true or false, /api/upload API payload must mention the 'includeSources' flag. When actual sources are getting uploaded, this flag should be true and it should be false for manifest based scan. SCA will error out if sources are getting uploaded when code upload is denied at the account level