### PR TITLE
Set project custom fields when creating/updating project for scan

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
- 	<version>0.5.04</version>
+ 	<version>0.5.06</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>


### PR DESCRIPTION
Just as we already support updating the preset, engine configuration and file and directory exclusions when creating a project, with this change we set the project's custom fields. This will be done if the project is created or, if the project already exists, the settings override flag has been set.

This lays the groundwork for implementing a solution to the following CxFlow issue: https://github.com/checkmarx-ltd/cx-flow/issues/730