### PR TITLE
Enable scan-level custom fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
- 	<version>0.5.08</version>
+ 	<version>0.5.09</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
- 	<version>0.5.06</version>
+ 	<version>0.5.08</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/dto/cx/CxScan.java
+++ b/src/main/java/com/checkmarx/sdk/dto/cx/CxScan.java
@@ -2,13 +2,15 @@ package com.checkmarx.sdk.dto.cx;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Map;
 
 @JsonPropertyOrder({
         "projectId",
         "isIncremental",
         "isPublic",
         "forceScan",
-        "comment"
+        "comment",
+        "customFields"
 })
 
 public class CxScan {
@@ -22,14 +24,17 @@ public class CxScan {
     public Boolean forceScan;
     @JsonProperty("comment")
     public String comment;
+    @JsonProperty("customFields")
+    public Map<String, String> customFields;
 
-    @java.beans.ConstructorProperties({"projectId", "isIncremental", "isPublic", "forceScan", "comment"})
-    CxScan(Integer projectId, Boolean isIncremental, Boolean isPublic, Boolean forceScan, String comment) {
+    @java.beans.ConstructorProperties({"projectId", "isIncremental", "isPublic", "forceScan", "comment", "customFields"})
+    CxScan(Integer projectId, Boolean isIncremental, Boolean isPublic, Boolean forceScan, String comment, Map<String, String> customFields) {
         this.projectId = projectId;
         this.isIncremental = isIncremental;
         this.isPublic = isPublic;
         this.forceScan = forceScan;
         this.comment = comment;
+        this.customFields = customFields;
     }
 
     public static CxScanBuilder builder() {
@@ -56,6 +61,10 @@ public class CxScan {
         return this.comment;
     }
 
+    public Map<String, String> getCustomFields() {
+        return this.customFields;
+    }
+
     public void setProjectId(Integer projectId) {
         this.projectId = projectId;
     }
@@ -76,8 +85,18 @@ public class CxScan {
         this.comment = comment;
     }
 
+    public void setCustomFields(Map<String, String> customFields) {
+        this.customFields = customFields;
+    }
+
     public String toString() {
-        return "CxScan(projectId=" + this.getProjectId() + ", isIncremental=" + this.getIsIncremental() + ", isPublic=" + this.getIsPublic() + ", forceScan=" + this.getForceScan() + ", comment=" + this.getComment() + ")";
+        return "CxScan(projectId=" + this.getProjectId() +
+                ", isIncremental=" + this.getIsIncremental() +
+                ", isPublic=" + this.getIsPublic() +
+                ", forceScan=" + this.getForceScan() +
+                ", comment=" + this.getComment() +
+                ", customFields=" + this.getCustomFields() +
+                ")";
     }
 
     public static class CxScanBuilder {
@@ -86,6 +105,7 @@ public class CxScan {
         private Boolean isPublic;
         private Boolean forceScan;
         private String comment;
+        private Map<String, String> customFields;
 
         CxScanBuilder() {
         }
@@ -115,12 +135,23 @@ public class CxScan {
             return this;
         }
 
+        public CxScan.CxScanBuilder customFields(Map<String, String> customFields) {
+            this.customFields = customFields;
+            return this;
+        }
+
         public CxScan build() {
-            return new CxScan(projectId, isIncremental, isPublic, forceScan, comment);
+            return new CxScan(projectId, isIncremental, isPublic, forceScan, comment, customFields);
         }
 
         public String toString() {
-            return "CxScan.CxScanBuilder(projectId=" + this.projectId + ", isIncremental=" + this.isIncremental + ", isPublic=" + this.isPublic + ", forceScan=" + this.forceScan + ", comment=" + this.comment + ")";
+            return "CxScan.CxScanBuilder(projectId=" + this.projectId +
+                    ", isIncremental=" + this.isIncremental +
+                    ", isPublic=" + this.isPublic +
+                    ", forceScan=" + this.forceScan +
+                    ", comment=" + this.comment +
+                    ", customFields=" + this.customFields +
+                    ")";
         }
     }
 }

--- a/src/main/java/com/checkmarx/sdk/dto/cx/CxScanParams.java
+++ b/src/main/java/com/checkmarx/sdk/dto/cx/CxScanParams.java
@@ -25,6 +25,7 @@ public class CxScanParams {
     private String filePath; //Only used if Type.FILE is used
     //TODO add custom fields
     private Map<String, String> customFields;
+    private Map<String, String> scanCustomFields;
     //TODO add add post actions
     private String postAction;
 
@@ -109,6 +110,14 @@ public class CxScanParams {
 
     public void setCustomFields(Map<String, String> customFields) {
         this.customFields = customFields;
+    }
+
+    public Map<String, String> getScanCustomFields() {
+        return scanCustomFields;
+    }
+
+    public void setScanCustomFields(Map<String, String> scanCustomFields) {
+        this.scanCustomFields = scanCustomFields;
     }
 
     public String getPostAction() {
@@ -228,6 +237,11 @@ public class CxScanParams {
         return this;
     }
 
+    public CxScanParams withScanCustomFields(Map<String, String> scanCustomFields) {
+        this.scanCustomFields = scanCustomFields;
+        return this;
+    }
+
     public CxScanParams withPostAction(String postAction) {
         this.postAction = postAction;
         return this;
@@ -323,6 +337,7 @@ public class CxScanParams {
                 ", gitUrl='" + gitUrl + '\'' +
                 ", filePath='" + filePath + '\'' +
                 ", customFields=" + customFields +
+                ", scanCustomFields=" + scanCustomFields +
                 ", postAction='" + postAction + '\'' +
                 '}';
     }

--- a/src/main/java/com/checkmarx/sdk/dto/sast/CxConfig.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sast/CxConfig.java
@@ -32,6 +32,8 @@ public class CxConfig implements Serializable {
     private String policy;
     @JsonProperty("customFields")
     private Map<String, String> customFields;
+    @JsonProperty("scanCustomFields")
+    private Map<String, String> scanCustomFields;
     @JsonProperty("sast")
     private Sast sast;
     @JsonProperty("osa")
@@ -129,6 +131,16 @@ public class CxConfig implements Serializable {
     @JsonProperty("customFields")
     public void setCustomFields(Map<String, String> customFields) {
         this.customFields = customFields;
+    }
+
+    @JsonProperty("scanCustomFields")
+    public Map<String, String> getScanCustomFields() {
+        return scanCustomFields;
+    }
+
+    @JsonProperty("scanCustomFields")
+    public void setScanCustomFields(Map<String, String> scanCustomFields) {
+        this.scanCustomFields = scanCustomFields;
     }
 
     @JsonProperty("sast")

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -1705,6 +1705,7 @@ public class CxService implements CxClient {
     @Override
     public Integer createScan(CxScanParams params, String comment) throws CheckmarxException{
         log.info("Creating scan...");
+        log.debug("Creating scan with params: {} and comment: \"{}\"", params, comment);
         validateScanParams(params);
         String teamId = determineTeamId(params);
         Integer projectId = determineProjectId(params, teamId);
@@ -1744,7 +1745,9 @@ public class CxService implements CxClient {
                 .forceScan(params.isForceScan())
                 .isPublic(params.isPublic())
                 .comment(comment)
+                .customFields(params.getScanCustomFields())
                 .build();
+        log.debug("scan: {}", scan);
 
         HttpHeaders headers = authClient.createAuthHeaders();
         headers.add(CxHttpClient.ORIGIN_HEADER, ScanClientHelper.CX_FLOW_SCAN_ORIGIN_NAME);


### PR DESCRIPTION
This PR adds support for scan-level custom fields to the Checkmarx Spring Boot Java SDK.

I have tested the changes against both CxSAST 9.4 and CxSAST 9.2.