### PR TITLE
added feature to support branched projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
- 	<version>0.5.07</version>
+ 	<version>0.5.08</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -55,6 +55,8 @@ public class CxProperties extends CxPropertiesBase{
 
     private Map<String, String> sshKeyList;
 
+    private Boolean cxBranch = false;
+
     /*
      * If set to true, group results by vulnerability, filename and
      * severity (by default, results are grouped only by vulnerability
@@ -292,6 +294,14 @@ public class CxProperties extends CxPropertiesBase{
 
     public void setSshKeyList(Map<String, String> sshKeyList) {
         this.sshKeyList = sshKeyList;
+    }
+
+    public Boolean getCxBranch() {
+        return cxBranch;
+    }
+
+    public void setCxBranch(Boolean cxBranch) {
+        this.cxBranch = cxBranch;
     }
 }
 

--- a/src/main/java/com/checkmarx/sdk/dto/cx/CxScanParams.java
+++ b/src/main/java/com/checkmarx/sdk/dto/cx/CxScanParams.java
@@ -21,6 +21,7 @@ public class CxScanParams {
     private Type sourceType = Type.GIT;
     private String gitUrl;
     private String branch;
+    private String defaultBranch;
     private String sshKeyIdentifier;
     private String filePath; //Only used if Type.FILE is used
     //TODO add custom fields
@@ -143,6 +144,14 @@ public class CxScanParams {
         this.branch = branch;
     }
 
+    public String getDefaultBranch() {
+        return defaultBranch;
+    }
+
+    public void setDefaultBranch(String defaultBranch) {
+        this.defaultBranch = defaultBranch;
+    }
+
     public String getFilePath() {
         return filePath;
     }
@@ -245,6 +254,11 @@ public class CxScanParams {
 
     public CxScanParams withBranch(String branch) {
         this.branch = branch;
+        return this;
+    }
+
+    public CxScanParams withDefaultBranch(String defaultBranch) {
+        this.defaultBranch = defaultBranch;
         return this;
     }
 

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -1728,7 +1728,7 @@ public class CxService implements CxClient {
             if(!baseProjectId.equals(UNKNOWN_INT) && cxProperties.getCxBranch()) {
                 projectId = branchProject(baseProjectId, params.getProjectName());
             }
-            if(baseProjectId.equals(UNKNOWN_INT)) {
+            if(baseProjectId.equals(UNKNOWN_INT) || !cxProperties.getCxBranch()) {
                 projectId = createProject(teamId, params.getProjectName());
             }
             if (projectId.equals(UNKNOWN_INT)) {

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -1710,7 +1710,27 @@ public class CxService implements CxClient {
         Integer projectId = determineProjectId(params, teamId);
         boolean projectExistedBeforeScan = !projectId.equals(UNKNOWN_INT);
         if (!projectExistedBeforeScan) {
-            projectId = createProject(teamId, params.getProjectName());
+            Integer baseProjectId = UNKNOWN_INT;
+            /*
+             When projectId = UNKNOWN_INT i.e -1, the below code checks if the current branch
+             and the default branch are equal or not. When the branches are not equal the code tries to retrieve the base
+             project id i.e. baseProjectId, if the value of baseProjectId != UNKNOWN_INT and the value of cxBranch property
+             is true then a branched project is created from the base project.
+             If the baseProjectId = UNKNOWN_INT then there was no base project present and a new normal project is created.
+             And if the default and current branches are same then a normal project is created.
+             */
+            if(!params.getBranch().equals(params.getDefaultBranch())) {
+                String currentBranch = params.getBranch().replace("refs/heads/","");
+                String defaultBranch = params.getDefaultBranch().replace("refs/heads/","");
+                String derivedProjectName = params.getProjectName().replace(currentBranch,defaultBranch);
+                baseProjectId = getProjectId(teamId,derivedProjectName);
+            }
+            if(!baseProjectId.equals(UNKNOWN_INT) && cxProperties.getCxBranch()) {
+                projectId = branchProject(baseProjectId, params.getProjectName());
+            }
+            if(baseProjectId.equals(UNKNOWN_INT)) {
+                projectId = createProject(teamId, params.getProjectName());
+            }
             if (projectId.equals(UNKNOWN_INT)) {
                 throw new CheckmarxException("Project was not created successfully: ".concat(params.getProjectName()));
             }


### PR DESCRIPTION
added feature to support branched projects from existing base project.
When projectId = UNKNOWN_INT i.e -1, the below code checks if the current branch and the default branch are equal or not. When the branches are not equal the code tries to retrieve the base project id i.e. baseProjectId, if the value of baseProjectId != UNKNOWN_INT and the value of cxBranch property is true then a branched project is created from the base project. If the baseProjectId = UNKNOWN_INT then there was no base project present and a new normal project is created. And if the default and current branches are same then a normal project is created.
