### PR TITLE
Add support for after/befor/failed scan email notifications

### DIFF
--- a/src/main/java/com/checkmarx/sdk/config/CxPropertiesBase.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxPropertiesBase.java
@@ -1,6 +1,6 @@
 package com.checkmarx.sdk.config;
 
-
+import com.checkmarx.sdk.dto.cx.CxEmailNotifications;
 import javax.annotation.PostConstruct;
 
 public abstract class CxPropertiesBase {
@@ -33,6 +33,7 @@ public abstract class CxPropertiesBase {
     private Boolean enablePostActionMonitor = false;
     private String postCloneScript;
     private Boolean enablePostActionEvent = false;
+    private CxEmailNotifications emailNotifications;
 
     private Boolean scanQueuing = false;
     private Integer scanQueuingTimeout = 720;
@@ -294,6 +295,14 @@ public abstract class CxPropertiesBase {
 
     public void setPostCloneScript(String postCloneScript) {
         this.postCloneScript = postCloneScript;
+    }
+
+    public CxEmailNotifications getEmailNotifications() {
+        return emailNotifications;
+    }
+
+    public void setEmailNotifications(CxEmailNotifications emailNotifications) {
+        this.emailNotifications = emailNotifications;
     }
 }
 

--- a/src/main/java/com/checkmarx/sdk/dto/cx/CxEmailNotifications.java
+++ b/src/main/java/com/checkmarx/sdk/dto/cx/CxEmailNotifications.java
@@ -1,0 +1,52 @@
+package com.checkmarx.sdk.dto.cx;
+
+//import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class CxEmailNotifications {
+    //@JsonProperty("afterScan")
+    private List<String> afterScan;
+    //@JsonProperty("beforeScan")
+    private List<String> beforeScan;
+    //@JsonProperty("failedScan")
+    private List<String> failedScan;
+
+    public CxEmailNotifications() {
+        this(null, null, null);
+    }
+
+    public CxEmailNotifications(List<String> afterScan, List<String> beforeScan, List<String> failedScan) {
+        this.afterScan = afterScan;
+        this.beforeScan = beforeScan;
+        this.failedScan = failedScan;
+    }
+
+    public List<String> getAfterScan() {
+        return afterScan;
+    }
+
+    public void setAfterScan(List<String> afterScan) {
+        this.afterScan = afterScan;
+    }
+
+    public List<String> getBeforeScan() {
+        return beforeScan;
+    }
+
+    public void setBeforeScan(List<String> beforeScan) {
+        this.beforeScan = beforeScan;
+    }
+
+    public List<String> getFailedScan() {
+        return failedScan;
+    }
+
+    public void setFailedScan(List<String> failedScan) {
+        this.failedScan = failedScan;
+    }
+
+    public String toString() {
+        return "CxScanSettings.EmailNotifications(afterScan=" + this.afterScan + ", beforeScan=" +
+                this.beforeScan + ", failedScan=" + this.failedScan + ")";
+    }
+}

--- a/src/main/java/com/checkmarx/sdk/dto/cx/CxScanParams.java
+++ b/src/main/java/com/checkmarx/sdk/dto/cx/CxScanParams.java
@@ -31,9 +31,7 @@ public class CxScanParams {
     //TODO add add post actions
     private String postAction;
     // Email notifications
-    private List<String> afterScanEmails;
-    private List<String> beforeScanEmails;
-    private List<String> failedScanEmails;
+    private CxEmailNotifications emailNotifications;
 
     @Getter
     private String clientSecret;
@@ -210,17 +208,9 @@ public class CxScanParams {
 
     public void setPreserveProjectName(Boolean preserveProjectName) { this.preserveProjectName = preserveProjectName; }
 
-    public List<String> getAfterScanEmails() { return afterScanEmails; }
+    public CxEmailNotifications getEmailNotifications() { return emailNotifications; }
 
-    public void setAfterScanEmails(List<String> afterScanEmails) { this.afterScanEmails = afterScanEmails; }
-
-    public List<String> getBeforeScanEmails() { return beforeScanEmails; }
-
-    public void setBeforeScanEmails(List<String> beforeScanEmails) { this.beforeScanEmails = beforeScanEmails; }
-
-    public List<String> getFailedScanEmails() { return failedScanEmails; }
-
-    public void setFailedScanEmails(List<String> failedScanEmails) { this.failedScanEmails = failedScanEmails; }
+    public void setEmailNotifications(CxEmailNotifications emailNotifications) { this.emailNotifications = emailNotifications; }
 
     public CxScanParams withIncremental(boolean incremental) {
         this.incremental = incremental;
@@ -338,18 +328,8 @@ public class CxScanParams {
         return this;
     }
 
-    public CxScanParams withAfterScanEmails(List<String> afterScanEmails) {
-        this.afterScanEmails = afterScanEmails;
-        return this;
-    }
-
-    public CxScanParams withBeforeScanEmails(List<String> beforeScanEmails) {
-        this.beforeScanEmails = beforeScanEmails;
-        return this;
-    }
-
-    public CxScanParams withFailedScanEmails(List<String> failedScanEmails) {
-        this.failedScanEmails = failedScanEmails;
+    public CxScanParams withEmailNotifications(CxEmailNotifications emailNotifications) {
+        this.emailNotifications = emailNotifications;
         return this;
     }
 
@@ -393,9 +373,7 @@ public class CxScanParams {
                 ", customFields=" + customFields +
                 ", scanCustomFields=" + scanCustomFields +
                 ", postAction='" + postAction + '\'' +
-                ", afterScanEmails='" + afterScanEmails + '\'' +
-                ", beforeScanEmails='" + beforeScanEmails + '\'' +
-                ", failedScanEmails='" + failedScanEmails + '\'' +
+                ", emailNotifications='" + emailNotifications + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/checkmarx/sdk/dto/cx/CxScanParams.java
+++ b/src/main/java/com/checkmarx/sdk/dto/cx/CxScanParams.java
@@ -30,6 +30,10 @@ public class CxScanParams {
     private Map<String, String> scanCustomFields;
     //TODO add add post actions
     private String postAction;
+    // Email notifications
+    private List<String> afterScanEmails;
+    private List<String> beforeScanEmails;
+    private List<String> failedScanEmails;
 
     @Getter
     private String clientSecret;
@@ -206,6 +210,18 @@ public class CxScanParams {
 
     public void setPreserveProjectName(Boolean preserveProjectName) { this.preserveProjectName = preserveProjectName; }
 
+    public List<String> getAfterScanEmails() { return afterScanEmails; }
+
+    public void setAfterScanEmails(List<String> afterScanEmails) { this.afterScanEmails = afterScanEmails; }
+
+    public List<String> getBeforeScanEmails() { return beforeScanEmails; }
+
+    public void setBeforeScanEmails(List<String> beforeScanEmails) { this.beforeScanEmails = beforeScanEmails; }
+
+    public List<String> getFailedScanEmails() { return failedScanEmails; }
+
+    public void setFailedScanEmails(List<String> failedScanEmails) { this.failedScanEmails = failedScanEmails; }
+
     public CxScanParams withIncremental(boolean incremental) {
         this.incremental = incremental;
         return this;
@@ -322,6 +338,20 @@ public class CxScanParams {
         return this;
     }
 
+    public CxScanParams withAfterScanEmails(List<String> afterScanEmails) {
+        this.afterScanEmails = afterScanEmails;
+        return this;
+    }
+
+    public CxScanParams withBeforeScanEmails(List<String> beforeScanEmails) {
+        this.beforeScanEmails = beforeScanEmails;
+        return this;
+    }
+
+    public CxScanParams withFailedScanEmails(List<String> failedScanEmails) {
+        this.failedScanEmails = failedScanEmails;
+        return this;
+    }
 
     public enum Type {
         GIT("GIT"),
@@ -363,6 +393,9 @@ public class CxScanParams {
                 ", customFields=" + customFields +
                 ", scanCustomFields=" + scanCustomFields +
                 ", postAction='" + postAction + '\'' +
+                ", afterScanEmails='" + afterScanEmails + '\'' +
+                ", beforeScanEmails='" + beforeScanEmails + '\'' +
+                ", failedScanEmails='" + failedScanEmails + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/checkmarx/sdk/dto/cx/CxScanSettings.java
+++ b/src/main/java/com/checkmarx/sdk/dto/cx/CxScanSettings.java
@@ -2,7 +2,6 @@ package com.checkmarx.sdk.dto.cx;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import java.util.List;
 
 @JsonPropertyOrder({
         "projectId",
@@ -21,12 +20,12 @@ public class CxScanSettings {
     @JsonProperty("postScanActionId")
     public Integer postScanActionId;
     @JsonProperty("emailNotifications")
-    public EmailNotifications emailNotifications;
+    public CxEmailNotifications emailNotifications;
 
 
     @java.beans.ConstructorProperties({"projectId", "presetId", "engineConfigurationId"})
     CxScanSettings(Integer projectId, Integer presetId, Integer engineConfigurationId, Integer postScanActionId,
-                   EmailNotifications emailNotifications) {
+                   CxEmailNotifications emailNotifications) {
         this.projectId = projectId;
         this.presetId = presetId;
         this.engineConfigurationId = engineConfigurationId;
@@ -79,7 +78,7 @@ public class CxScanSettings {
         private Integer presetId;
         private Integer engineConfigurationId;
         private Integer postScanActionId;
-        private EmailNotifications emailNotifications;
+        private CxEmailNotifications emailNotifications;
 
         CxScanSettingsBuilder() {
         }
@@ -104,7 +103,7 @@ public class CxScanSettings {
             return this;
         }
 
-        public CxScanSettings.CxScanSettingsBuilder emailNotifications(EmailNotifications emailNotifications) {
+        public CxScanSettings.CxScanSettingsBuilder emailNotifications(CxEmailNotifications emailNotifications) {
             this.emailNotifications = emailNotifications;
             return this;
         }
@@ -118,26 +117,6 @@ public class CxScanSettings {
             return "CxScanSettings.CxScanSettingsBuilder(projectId=" + this.projectId + ", presetId=" +
                     this.presetId + ", engineConfigurationId=" + this.engineConfigurationId +
                     "this.emailNotifications=" + emailNotifications + ")";
-        }
-    }
-
-    public static class EmailNotifications {
-        @JsonProperty("afterScan")
-        public List<String> afterScan;
-        @JsonProperty("beforeScan")
-        public List<String> beforeScan;
-        @JsonProperty("failedScan")
-        public List<String> failedScan;
-
-        public EmailNotifications(List<String> afterScan, List<String> beforeScan, List<String> failedScan) {
-            this.afterScan = afterScan;
-            this.beforeScan = beforeScan;
-            this.failedScan = failedScan;
-        }
-
-        public String toString() {
-            return "CxScanSettings.EmailNotifications(afterScan=" + this.afterScan + ", beforeScan=" +
-                    this.beforeScan + ", failedScan=" + this.failedScan + ")";
         }
     }
 }

--- a/src/main/java/com/checkmarx/sdk/dto/cx/CxScanSettings.java
+++ b/src/main/java/com/checkmarx/sdk/dto/cx/CxScanSettings.java
@@ -2,6 +2,7 @@ package com.checkmarx.sdk.dto.cx;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.List;
 
 @JsonPropertyOrder({
         "projectId",
@@ -19,14 +20,18 @@ public class CxScanSettings {
     public Integer engineConfigurationId;
     @JsonProperty("postScanActionId")
     public Integer postScanActionId;
+    @JsonProperty("emailNotifications")
+    public EmailNotifications emailNotifications;
 
 
     @java.beans.ConstructorProperties({"projectId", "presetId", "engineConfigurationId"})
-    CxScanSettings(Integer projectId, Integer presetId, Integer engineConfigurationId, Integer postScanActionId) {
+    CxScanSettings(Integer projectId, Integer presetId, Integer engineConfigurationId, Integer postScanActionId,
+                   EmailNotifications emailNotifications) {
         this.projectId = projectId;
         this.presetId = presetId;
         this.engineConfigurationId = engineConfigurationId;
         this.postScanActionId = postScanActionId;
+        this.emailNotifications = emailNotifications;
     }
 
     public static CxScanSettingsBuilder builder() {
@@ -74,6 +79,7 @@ public class CxScanSettings {
         private Integer presetId;
         private Integer engineConfigurationId;
         private Integer postScanActionId;
+        private EmailNotifications emailNotifications;
 
         CxScanSettingsBuilder() {
         }
@@ -98,12 +104,40 @@ public class CxScanSettings {
             return this;
         }
 
+        public CxScanSettings.CxScanSettingsBuilder emailNotifications(EmailNotifications emailNotifications) {
+            this.emailNotifications = emailNotifications;
+            return this;
+        }
+
         public CxScanSettings build() {
-            return new CxScanSettings(projectId, presetId, engineConfigurationId, postScanActionId);
+            return new CxScanSettings(projectId, presetId, engineConfigurationId, postScanActionId,
+                    emailNotifications);
         }
 
         public String toString() {
-            return "CxScanSettings.CxScanSettingsBuilder(projectId=" + this.projectId + ", presetId=" + this.presetId + ", engineConfigurationId=" + this.engineConfigurationId + ")";
+            return "CxScanSettings.CxScanSettingsBuilder(projectId=" + this.projectId + ", presetId=" +
+                    this.presetId + ", engineConfigurationId=" + this.engineConfigurationId +
+                    "this.emailNotifications=" + emailNotifications + ")";
+        }
+    }
+
+    public static class EmailNotifications {
+        @JsonProperty("afterScan")
+        public List<String> afterScan;
+        @JsonProperty("beforeScan")
+        public List<String> beforeScan;
+        @JsonProperty("failedScan")
+        public List<String> failedScan;
+
+        public EmailNotifications(List<String> afterScan, List<String> beforeScan, List<String> failedScan) {
+            this.afterScan = afterScan;
+            this.beforeScan = beforeScan;
+            this.failedScan = failedScan;
+        }
+
+        public String toString() {
+            return "CxScanSettings.EmailNotifications(afterScan=" + this.afterScan + ", beforeScan=" +
+                    this.beforeScan + ", failedScan=" + this.failedScan + ")";
         }
     }
 }

--- a/src/main/java/com/checkmarx/sdk/dto/sast/CxConfig.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sast/CxConfig.java
@@ -1,6 +1,7 @@
 package com.checkmarx.sdk.dto.sast;
 
 import com.checkmarx.sdk.dto.Osa;
+import com.checkmarx.sdk.dto.cx.CxEmailNotifications;
 import com.checkmarx.sdk.dto.sca.Sca;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -42,6 +43,8 @@ public class CxConfig implements Serializable {
     private Map<String, Object> additionalProperties = new HashMap<>();
     @JsonProperty("sca")
     private Sca sca;
+    @JsonProperty("emailNotifications")
+    private CxEmailNotifications emailNotifications;
 
     private static final long serialVersionUID = 2851455437649831239L;
 
@@ -171,5 +174,13 @@ public class CxConfig implements Serializable {
     @JsonAnySetter
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
+    }
+
+    @JsonProperty("emailNotifications")
+    public CxEmailNotifications getEmailNotifications() { return emailNotifications; }
+
+    @JsonProperty("emailNotifications")
+    public void setEmailNotifications(CxEmailNotifications emailNotifications) {
+        this.emailNotifications = emailNotifications;
     }
 }

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -1152,10 +1152,9 @@ public class CxService implements CxClient {
      * @return Scan setting ID.
      */
     public Integer createScanSetting(Integer projectId, Integer presetId, Integer engineConfigId,
-                                     Integer postActionId, List<String> afterScanEmails,
-                                     List<String> beforeScanEmails, List<String> failedScanEmails) {
+                                     Integer postActionId, CxEmailNotifications emailNotifications) {
         return scanSettingsClient.createScanSettings(projectId, presetId, engineConfigId, postActionId,
-                afterScanEmails, beforeScanEmails, failedScanEmails);
+                emailNotifications);
     }
 
     /**
@@ -1755,7 +1754,7 @@ public class CxService implements CxClient {
             Integer presetId = getPresetId(params.getScanPreset());
             Integer engineConfigurationId = getScanConfiguration(params.getScanConfiguration());
             createScanSetting(projectId, presetId, engineConfigurationId, cxProperties.getPostActionPostbackId(),
-                    params.getAfterScanEmails(), params.getBeforeScanEmails(), params.getFailedScanEmails());
+                    params.getEmailNotifications());
             setProjectExcludeDetails(projectId, params.getFolderExclude(), params.getFileExclude());
             if (params.getCustomFields() != null && !params.getCustomFields().isEmpty()) {
                 List<CxCustomField> fieldDefinitions = getCustomFields();

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -1145,7 +1145,6 @@ public class CxService implements CxClient {
         return UNKNOWN_INT;
     }
 
-
     /**
      * Create Scan Settings
      *
@@ -1155,6 +1154,16 @@ public class CxService implements CxClient {
                                      Integer postActionId, CxEmailNotifications emailNotifications) {
         return scanSettingsClient.createScanSettings(projectId, presetId, engineConfigId, postActionId,
                 emailNotifications);
+    }
+
+    /**
+     * Create Scan Settings
+     *
+     * @return Scan setting ID.
+     */
+    public Integer createScanSetting(Integer projectId, Integer presetId, Integer engineConfigId,
+                                     Integer postActionId) {
+        return createScanSetting(projectId, presetId, engineConfigId, postActionId, null);
     }
 
     /**

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -1151,8 +1151,11 @@ public class CxService implements CxClient {
      *
      * @return Scan setting ID.
      */
-    public Integer createScanSetting(Integer projectId, Integer presetId, Integer engineConfigId, Integer postActionId) {
-        return scanSettingsClient.createScanSettings(projectId, presetId, engineConfigId, postActionId);
+    public Integer createScanSetting(Integer projectId, Integer presetId, Integer engineConfigId,
+                                     Integer postActionId, List<String> afterScanEmails,
+                                     List<String> beforeScanEmails, List<String> failedScanEmails) {
+        return scanSettingsClient.createScanSettings(projectId, presetId, engineConfigId, postActionId,
+                afterScanEmails, beforeScanEmails, failedScanEmails);
     }
 
     /**
@@ -1751,7 +1754,8 @@ public class CxService implements CxClient {
             log.debug("Updating project...");
             Integer presetId = getPresetId(params.getScanPreset());
             Integer engineConfigurationId = getScanConfiguration(params.getScanConfiguration());
-            createScanSetting(projectId, presetId, engineConfigurationId, cxProperties.getPostActionPostbackId());
+            createScanSetting(projectId, presetId, engineConfigurationId, cxProperties.getPostActionPostbackId(),
+                    params.getAfterScanEmails(), params.getBeforeScanEmails(), params.getFailedScanEmails());
             setProjectExcludeDetails(projectId, params.getFolderExclude(), params.getFileExclude());
             if (params.getCustomFields() != null && !params.getCustomFields().isEmpty()) {
                 List<CxCustomField> fieldDefinitions = getCustomFields();

--- a/src/main/java/com/checkmarx/sdk/service/ScanSettingsClient.java
+++ b/src/main/java/com/checkmarx/sdk/service/ScanSettingsClient.java
@@ -1,8 +1,8 @@
 package com.checkmarx.sdk.service;
 
+import com.checkmarx.sdk.dto.cx.CxEmailNotifications;
 import com.checkmarx.sdk.dto.cx.CxScanSettings;
 import com.checkmarx.sdk.exception.CheckmarxException;
-import java.util.List;
 
 /**
  * Works with scan settings. The settings contain<br>
@@ -11,8 +11,7 @@ import java.util.List;
  */
 public interface ScanSettingsClient {
     int createScanSettings(int projectId, int presetId, int engineConfigId, int postScanId,
-                           List<String> afterScanEmail, List<String> beforeScanEmail,
-                           List<String> failedScanEmail);
+                           CxEmailNotifications emailNotifications);
 
     String getScanSettings(int projectId);
 

--- a/src/main/java/com/checkmarx/sdk/service/ScanSettingsClient.java
+++ b/src/main/java/com/checkmarx/sdk/service/ScanSettingsClient.java
@@ -10,6 +10,8 @@ import com.checkmarx.sdk.exception.CheckmarxException;
  * - scan presets
  */
 public interface ScanSettingsClient {
+    int createScanSettings(int projectId, int presetId, int engineConfigId, int postScanId);
+
     int createScanSettings(int projectId, int presetId, int engineConfigId, int postScanId,
                            CxEmailNotifications emailNotifications);
 

--- a/src/main/java/com/checkmarx/sdk/service/ScanSettingsClient.java
+++ b/src/main/java/com/checkmarx/sdk/service/ScanSettingsClient.java
@@ -2,6 +2,7 @@ package com.checkmarx.sdk.service;
 
 import com.checkmarx.sdk.dto.cx.CxScanSettings;
 import com.checkmarx.sdk.exception.CheckmarxException;
+import java.util.List;
 
 /**
  * Works with scan settings. The settings contain<br>
@@ -9,7 +10,9 @@ import com.checkmarx.sdk.exception.CheckmarxException;
  * - scan presets
  */
 public interface ScanSettingsClient {
-    int createScanSettings(int projectId, int presetId, int engineConfigId, int postScanId);
+    int createScanSettings(int projectId, int presetId, int engineConfigId, int postScanId,
+                           List<String> afterScanEmail, List<String> beforeScanEmail,
+                           List<String> failedScanEmail);
 
     String getScanSettings(int projectId);
 

--- a/src/main/java/com/checkmarx/sdk/service/ScanSettingsClientImpl.java
+++ b/src/main/java/com/checkmarx/sdk/service/ScanSettingsClientImpl.java
@@ -22,6 +22,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
+import java.util.List;
 
 @Service
 @Slf4j
@@ -54,11 +55,16 @@ public class ScanSettingsClientImpl implements ScanSettingsClient {
     }
 
     @Override
-    public int createScanSettings(int projectId, int presetId, int engineConfigId, int postActionId) {
+    public int createScanSettings(int projectId, int presetId, int engineConfigId, int postActionId,
+                                  List<String> afterScanEmails, List<String> beforeScanEmails,
+                                  List<String> failedScanEmails) {
+        CxScanSettings.EmailNotifications emailNotifications =
+                new CxScanSettings.EmailNotifications(afterScanEmails, beforeScanEmails, failedScanEmails);
         CxScanSettings scanSettings = CxScanSettings.builder()
                 .projectId(projectId)
                 .engineConfigurationId(engineConfigId)
                 .presetId(presetId)
+                .emailNotifications(emailNotifications)
                 .build();
         if(cxProperties.getEnablePostActionEvent() && postActionId != 0)
             scanSettings.setPostScanActionId(postActionId);

--- a/src/main/java/com/checkmarx/sdk/service/ScanSettingsClientImpl.java
+++ b/src/main/java/com/checkmarx/sdk/service/ScanSettingsClientImpl.java
@@ -56,6 +56,11 @@ public class ScanSettingsClientImpl implements ScanSettingsClient {
     }
 
     @Override
+    public int createScanSettings(int projectId, int presetId, int engineConfigId, int postActionId) {
+        return createScanSettings(projectId, presetId, engineConfigId, postActionId, null);
+    }
+
+    @Override
     public int createScanSettings(int projectId, int presetId, int engineConfigId, int postActionId,
                                   CxEmailNotifications emailNotifications) {
         CxScanSettings scanSettings = CxScanSettings.builder()

--- a/src/main/java/com/checkmarx/sdk/service/ScanSettingsClientImpl.java
+++ b/src/main/java/com/checkmarx/sdk/service/ScanSettingsClientImpl.java
@@ -2,6 +2,7 @@ package com.checkmarx.sdk.service;
 
 import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxProperties;
+import com.checkmarx.sdk.dto.cx.CxEmailNotifications;
 import com.checkmarx.sdk.dto.cx.CxPreset;
 import com.checkmarx.sdk.dto.cx.CxScanEngine;
 import com.checkmarx.sdk.dto.cx.CxScanSettings;
@@ -56,10 +57,7 @@ public class ScanSettingsClientImpl implements ScanSettingsClient {
 
     @Override
     public int createScanSettings(int projectId, int presetId, int engineConfigId, int postActionId,
-                                  List<String> afterScanEmails, List<String> beforeScanEmails,
-                                  List<String> failedScanEmails) {
-        CxScanSettings.EmailNotifications emailNotifications =
-                new CxScanSettings.EmailNotifications(afterScanEmails, beforeScanEmails, failedScanEmails);
+                                  CxEmailNotifications emailNotifications) {
         CxScanSettings scanSettings = CxScanSettings.builder()
                 .projectId(projectId)
                 .engineConfigurationId(engineConfigId)

--- a/src/main/java/com/checkmarx/sdk/service/scanner/CxClient.java
+++ b/src/main/java/com/checkmarx/sdk/service/scanner/CxClient.java
@@ -207,6 +207,10 @@ public interface CxClient extends ILegacyClient {
      * @param projectId
      * @param presetId
      * @param engineConfigId
+     * @param postBackId
+     * @param afterScanEmails
+     * @param beforeScanEmails
+     * @param failedScanEmails
      * @return ID for scan settings
      */
     public Integer createScanSetting(Integer projectId, Integer presetId, Integer engineConfigId,

--- a/src/main/java/com/checkmarx/sdk/service/scanner/CxClient.java
+++ b/src/main/java/com/checkmarx/sdk/service/scanner/CxClient.java
@@ -208,14 +208,11 @@ public interface CxClient extends ILegacyClient {
      * @param presetId
      * @param engineConfigId
      * @param postBackId
-     * @param afterScanEmails
-     * @param beforeScanEmails
-     * @param failedScanEmails
+     * @param emailNotifications
      * @return ID for scan settings
      */
     public Integer createScanSetting(Integer projectId, Integer presetId, Integer engineConfigId,
-                                     Integer postBackId, List<String> afterScanEmails,
-                                     List<String> beforeScanEmails, List<String> failedScanEmails);
+                                     Integer postBackId, CxEmailNotifications emailNotifications);
 
     /**
      * Get Scan Settings for an existing project (JSON String)

--- a/src/main/java/com/checkmarx/sdk/service/scanner/CxClient.java
+++ b/src/main/java/com/checkmarx/sdk/service/scanner/CxClient.java
@@ -209,7 +209,9 @@ public interface CxClient extends ILegacyClient {
      * @param engineConfigId
      * @return ID for scan settings
      */
-    public Integer createScanSetting(Integer projectId, Integer presetId, Integer engineConfigId, Integer postBackId);
+    public Integer createScanSetting(Integer projectId, Integer presetId, Integer engineConfigId,
+                                     Integer postBackId, List<String> afterScanEmails,
+                                     List<String> beforeScanEmails, List<String> failedScanEmails);
 
     /**
      * Get Scan Settings for an existing project (JSON String)


### PR DESCRIPTION
This PR adds support for the setting of email recipients for notifications sent before and after a CxSAST scan runs and when a scan CxSAST fails.

I have tested this change manually using a private version of the cx-java-util application with the appropriate enhancements.