### PR TITLE
[JIRA:CXFLW-47] CxFlow: Don't group findings for Sarif - GH Action Security Updates

### DIFF
--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -64,6 +64,13 @@ public class CxProperties extends CxPropertiesBase{
      */
     private Boolean groupBySeverity = false;
 
+    /*
+     * If set to true, results are not grouped at all
+     * (by default, results are grouped only by vulnerability
+     * and filename. Setting default to false).
+     */
+    private Boolean disableClubbing = false;
+
     /**
      * Maps finding state ID (as returned in CxSAST report) to state name (as specified in filter configuration).
      */
@@ -302,6 +309,14 @@ public class CxProperties extends CxPropertiesBase{
 
     public void setCxBranch(Boolean cxBranch) {
         this.cxBranch = cxBranch;
+    }
+
+    public Boolean getDisableClubbing() {
+        return disableClubbing;
+    }
+
+    public void setDisableClubbing(Boolean disableClubbing) {
+        this.disableClubbing = disableClubbing;
     }
 }
 


### PR DESCRIPTION
- For SAST Scan Result “Query->Result->Path” should match the “Sarif Issues->Show Path”. Flag will be used to enable/disable this functionality but will use starter workflow to set this flag default value in case of github actions. 

> e.g.:- [starter-workflows/checkmarx.yml at main actions/starter-workflows](https://github.com/actions/starter-workflows/blob/main/code-scanning/checkmarx.yml) .

- Flag "--checkmarx.disable-clubbing=true" for GitHub Actions where SARIF is bug tracker, default value is false.
