### PR TITLE
Get email notification configuration for scan from cxProperties

### DIFF
--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -2394,6 +2394,9 @@ public class CxService implements CxClient {
         }else{
             throw new CheckmarxException("No source type was provided for the scan");
         }
+        if(params.getEmailNotifications() == null && cxProperties.getEmailNotifications() != null) {
+            params.setEmailNotifications(cxProperties.getEmailNotifications());
+        }
     }
 
     /**


### PR DESCRIPTION
This was an omission from my earlier pull request for this functionality.

If the scan parameters do not include email notification configuration but `cxProperties` does, use the configuration from `cxProperties` (in the same way that we do for several other pieces of configuration).

This allows the email notifications to be specified in the `application.yml` file or on the command line.