### PR TITLE
Fixed Summary Issue with multiple vulnerabilities of the same type in same file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
 
- 	<version>0.5.19</version>
+ 	<version>0.5.20</version>
 
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -927,10 +927,27 @@ public class CxService implements CxClient {
                     summary.put(resultType.getSeverity(), severityCount);
                 }
             }
+                //adding description if existing ref found
+
+            StringBuilder stringBuilder = new StringBuilder();
+            if(issue.getVulnerabilityStatus()==null)
+            {
+                cxIssueList.get(cxIssueList.indexOf(issue)).setDescription(existingIssue.getDescription());
+            }
+            else if(existingIssue.getVulnerabilityStatus()!=null )
+            {
+                String existingIssueDescription = existingIssue.getDescription();
+                String newIssueDescription = issue.getDescription();
+                stringBuilder.append(existingIssueDescription).append("\r\n").append("\r\n").append(newIssueDescription);
+                cxIssueList.get(cxIssueList.indexOf(issue)).setDescription(stringBuilder.toString());
+            }
+            else{
+                cxIssueList.get(cxIssueList.indexOf(issue)).setDescription(issue.getDescription());
+            }
+
             // Copy additionalData.results from issue to existingIssue
             List<Map<String, Object>> results = (List<Map<String, Object>>) existingIssue.getAdditionalDetails().get("results");
             results.addAll((List<Map<String, Object>>)issue.getAdditionalDetails().get("results"));
-
         } else {
             if(falsePositive) {
                 issue.setFalsePositiveCount((issue.getFalsePositiveCount()+1));


### PR DESCRIPTION
### Problem

Issue present with multiple vulnerabilities of the same type in same file was not getting generated.

When marked one of them as Not Exploitable and it was still "choosen" for the summary instead of any other vulnerability of the same type in the same file.

### Solution
Currently if multiple vulnerabilities of the same type in same file is present it generates all vulnerablities summary.

When marked one of them as Not Exploitable that summary is not updated 

### References

https://github.com/checkmarx-ltd/cx-flow/issues/914

### Testing

Have tested this issue with 9.4 and 9.5 SAST version on bugTracker as JIRA, GitLab, GitHub.


