### PR TITLE
Add scan-level custom fields to results

### DIFF
--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -567,6 +567,10 @@ public class CxService implements CxClient {
                 if (scanState != null) {
                     additionalDetails.put("numFailedLoc", String.valueOf(scanState.getInt("failedLinesOfCode")));
                 }
+                JSONObject scanCustomFields = jsonObject.getJSONObject("customFields");
+                if (scanCustomFields != null) {
+                    additionalDetails.put("scanCustomFields", scanCustomFields.toMap());
+                }
             }
 
             // Add custom field values if requested


### PR DESCRIPTION
This PR addresses issue #233.

Tested manually using CxFlow. Here is an excerpt from the Json output file (for the Json bug tracker):

```
{
    "projectId": "171",
    "team": "CxServer",
    "project": "scan-custom-fields",
    "link": "http://ec2amaz-3tsivek/CxWebClient/ViewerMain.aspx?scanid=1000248&projectid=171",
    "files": "3",
    "loc": "102",
    "scanType": "Full",
    "additionalDetails": {
        "flow-summary": {
            "High": 1
        },
        "numFailedLoc": "0",
        "scanRiskSeverity": "0",
        "scanId": "1000248",
        "scanStartDate": "Monday, July 11, 2022 12:16:04 AM",
        "customFields": {},
        "scanRisk": "0",
        "scanCustomFields": {
            "one": "ant",
            "two": "bat"
        }
    },
```