### PR TITLE
Check project branching status

### DIFF
--- a/src/main/java/com/checkmarx/sdk/config/CxPropertiesBase.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxPropertiesBase.java
@@ -38,6 +38,9 @@ public abstract class CxPropertiesBase {
 
     private Boolean scanQueuing = false;
     private Integer scanQueuingTimeout = 720;
+
+    private Integer projectBranchingCheckCount = 3;
+    private Integer projectBranchingCheckInterval = 5;
     
     public abstract Boolean getEnableOsa();
 
@@ -310,6 +313,22 @@ public abstract class CxPropertiesBase {
 
     public void setDetectionDateFormat(String detectionDateFormat) {
         this.detectionDateFormat = detectionDateFormat;
+    }
+
+    public Integer getProjectBranchingCheckCount() {
+        return projectBranchingCheckCount;
+    }
+
+    public void setProjectBranchingCheckCount(Integer projectBranchingCheckCount) {
+        this.projectBranchingCheckCount = projectBranchingCheckCount;
+    }
+
+    public Integer getProjectBranchingCheckInterval() {
+        return projectBranchingCheckInterval;
+    }
+
+    public void setProjectBranchingCheckInterval(Integer projectBranchingCheckInterval) {
+        this.projectBranchingCheckInterval = projectBranchingCheckInterval;
     }
 }
 

--- a/src/main/java/com/checkmarx/sdk/dto/cx/CxProjectBranchingStatus.java
+++ b/src/main/java/com/checkmarx/sdk/dto/cx/CxProjectBranchingStatus.java
@@ -1,0 +1,31 @@
+package com.checkmarx.sdk.dto.cx;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
+@Value
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class CxProjectBranchingStatus {
+    private Integer id;
+    private Integer originalProjectId;
+    private String originalProjectName;
+    private Integer branchedOnScanId;
+    private Integer branchedProjectId;
+    private LocalDateTime timestamp;
+    private String comment;
+    private Status status;
+    private String errorMessage;
+
+    @Value
+    @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+    @AllArgsConstructor
+    public static class Status {
+        private Integer id;
+        private String value;
+    }
+}

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -1112,7 +1112,10 @@ public class CxService implements CxClient {
         try {
             ResponseEntity<CxProjectBranchingStatus> response = restTemplate.exchange(cxProperties.getUrl().concat(PROJECT_BRANCH_STATUS),
                     HttpMethod.GET, httpEntity, CxProjectBranchingStatus.class, projectId);
-            return response.getBody();
+            CxProjectBranchingStatus branchingStatus = response.getBody();
+            log.debug("Branching status is {} ({})", branchingStatus.getStatus().getId(),
+                    branchingStatus.getStatus().getValue());
+            return branchingStatus;
         } catch (HttpStatusCodeException e) {
             if (e.getStatusCode() != HttpStatus.NOT_FOUND) {
                 log.error(ERROR_GETTING_PROJECT, projectId, e.getStatusCode());

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -3,6 +3,7 @@ package com.checkmarx.sdk.service;
 import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.config.CxPropertiesBase;
+import com.checkmarx.sdk.dto.cx.CxProjectBranchingStatus;
 import com.checkmarx.sdk.dto.sast.Filter;
 import com.checkmarx.sdk.dto.ScanResults;
 import com.checkmarx.sdk.dto.cx.*;
@@ -85,6 +86,7 @@ public class CxService implements CxClient {
     private static final Integer SCAN_STATUS_SOURCE_PULLING = 10;
     private static final Integer SCAN_STATUS_NONE = 1001;
 
+    private static final Integer MESSAGE_CODE_BRANCH_NOT_FOUND = 49805;
 
     /*
     report statuses - there are only 2:
@@ -107,6 +109,7 @@ public class CxService implements CxClient {
     private static final String PROJECTS = "/projects";
     private static final String PROJECT = "/projects/{id}";
     private static final String PROJECT_BRANCH = "/projects/{id}/branch";
+    private static final String PROJECT_BRANCH_STATUS = "/projects/branch/{id}";
     private static final String PROJECT_SOURCE = "/projects/{id}/sourceCode/remoteSettings/git";
     private static final String PROJECT_SOURCE_FILE = "/projects/{id}/sourceCode/attachments";
     private static final String PROJECT_EXCLUDE = "/projects/{id}/sourceCode/excludeSettings";
@@ -1099,6 +1102,55 @@ public class CxService implements CxClient {
         return UNKNOWN_INT;
     }
 
+    /**
+     * @param projectId the ID of the project whose branching status is to be retrieved
+     * @return the branching status of the specified project (will return null if the relevant API is not available)
+     */
+    public CxProjectBranchingStatus getProjectBranchingStatus(Integer projectId) {
+        log.debug("Retrieving branching status of project {}", projectId);
+        HttpEntity httpEntity = new HttpEntity<>(authClient.createAuthHeaders());
+        try {
+            ResponseEntity<CxProjectBranchingStatus> response = restTemplate.exchange(cxProperties.getUrl().concat(PROJECT_BRANCH_STATUS),
+                    HttpMethod.GET, httpEntity, CxProjectBranchingStatus.class, projectId);
+            return response.getBody();
+        } catch (HttpStatusCodeException e) {
+            if (e.getStatusCode() != HttpStatus.NOT_FOUND) {
+                log.error(ERROR_GETTING_PROJECT, projectId, e.getStatusCode());
+                log.error(ExceptionUtils.getStackTrace(e));
+            } else {
+                /*
+                 * For version X.Y and higher of the SAST API, if a project is not branched, a 404 response will
+                 * be returned and the body of the response will be JSON data:
+                 *
+                 * {
+                 *     "messageCode": 48905,
+                 *     "messageDetails": "Branch with id 168 was not found"
+                 * }
+                 *
+                 * For earlier versions of the SAST API, the body will be a HTML document with a generic
+                 * "resource not found" message.
+                 */
+                String responseBody = e.getResponseBodyAsString();
+                try {
+                    JSONObject obj = new JSONObject(responseBody);
+                    int messageCode = obj.optInt("messageCode");
+                    if (messageCode == MESSAGE_CODE_BRANCH_NOT_FOUND) {
+                        log.debug("Project {} is not a branched project", projectId);
+                    } else {
+                        String messageDetails = obj.optString("messageDetails");
+                        log.debug("{}: unexpected message code in response (messageDetails: {})", messageCode, messageDetails);
+                    }
+                } catch (JSONException je) {
+                    log.debug("Response payload is not JSON. Assuming a version of SAST that does not support the GET /projects/branch/{id} API");
+                }
+            }
+        } catch (JSONException e) {
+            log.error("Error processing JSON Response");
+            log.error(ExceptionUtils.getStackTrace(e));
+        }
+
+        return null;
+    }
     /**
      * Get All Projects in Checkmarx
      */


### PR DESCRIPTION
Branching a project is not instantaneous. At least one client has reported scans being canceled due to CxFlow launching a scan before project branching has finished.

```
2022-11-29 11:12:23,466 [68] INFO - JobsManager - ExecuteJob: Received new job details: JobDetails[Id: 2075808, RequestId:1480, Owner:1c517a3b-bfc5-a86f-64bf-ca8f2e480023, Type:BranchProject, Creation Time 11/29/2022 11:12:22 AM]

2022-11-29 11:12:23,492 [104] INFO - Branch project job has started...

2022-11-29 11:12:58,995 [104] INFO - Checkmarx.CxJobsManager.Jobs.ProjectJob.BranchProjectJob - Execute: Leaving job of type BranchProject, request id 1480

 

So at 2022-11-29 11:12:22.779 when the scan was created, the branched Project was not ready to be scanned. Thus causing the scan cancelation:
```

This PR changes the SDK so that, after initiating the branching of a project, there is a pause before continuing. On versions of CxSAST that support querying the branching status, this is used to determine when to proceed; on older versions, the pause is unconditional. Configuration properties have been added to specify the length of the pause (default is 5 seconds), and the number of times to query the project's branching status (default is 3).

This change was tested against versions 9.3 and 9.5 of CxSAST using a modified version of the cx-java-util program (see https://github.com/checkmarx-ts/cx-java-util/tree/pr-project-branch-and-branch-status).

CxJavaUtil command and log for CxSAST 9.3:

```
$ java -jar build/libs/cx-java-util-0.5.0-SNAPSHOT.jar project branch -t CxServer DSVW DSVW-branch1

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::                (v2.7.6)

2022-12-15 08:24:04.052  INFO 11816 --- [           main] c.c.util.CheckmarxUtilApplication        : Starting CheckmarxUtilApplication using Java 1.8.0_282 on JamesB-Laptop with PID 11816 (C:\Users\JamesBo\Documents\src\checkmarx-ts\cx-java-util\build\libs\cx-java-util-0.5.0-SNAPSHOT.jar started by JamesBo in C:\Users\JamesBo\Documents\src\checkmarx-ts\cx-java-util)
2022-12-15 08:24:04.055 DEBUG 11816 --- [           main] c.c.util.CheckmarxUtilApplication        : Running with Spring Boot v2.7.6, Spring v5.3.24
2022-12-15 08:24:04.055  INFO 11816 --- [           main] c.c.util.CheckmarxUtilApplication        : No active profile set, falling back to 1 default profile: "default"
2022-12-15 08:24:07.481  INFO 11816 --- [           main] o.s.ws.soap.saaj.SaajSoapMessageFactory  : Creating SAAJ 1.3 MessageFactory with SOAP 1.1 Protocol
2022-12-15 08:24:08.840  INFO 11816 --- [           main] c.c.util.CheckmarxUtilApplication        : Started CheckmarxUtilApplication in 5.347 seconds (JVM running for 5.967)
2022-12-15 08:24:08.841 DEBUG 11816 --- [           main] com.checkmarx.util.CheckmarxUtilRunner   : run: starting
2022-12-15 08:24:08.997  INFO 11816 --- [           main] com.checkmarx.util.cmd.ProjectCommand    : Calling project branch command: project: DSVW, branch: DSVW-branch1
2022-12-15 08:24:08.999 DEBUG 11816 --- [           main] com.checkmarx.util.cmd.ProjectCommand    : getCxProjects: project: DSVW, team: CxServer
2022-12-15 08:24:08.999 DEBUG 11816 --- [           main] com.checkmarx.util.cmd.ProjectCommand    : getCxProjects: project: DSVW, team: CxServer
2022-12-15 08:24:09.005  INFO 11816 --- [           main] com.checkmarx.sdk.service.CxAuthService  : Logging into Checkmarx http://172.35.1.146/cxrestapi/auth/identity/connect/token
2022-12-15 08:24:10.088  INFO 11816 --- [           main] com.checkmarx.sdk.service.CxService      : Retrieving Cx teams
2022-12-15 08:24:10.351 DEBUG 11816 --- [           main] com.checkmarx.util.cmd.ProjectCommand    : getTeamId: found team /CxServer with ID 1
2022-12-15 08:24:14.219 DEBUG 11816 --- [           main] com.checkmarx.util.cmd.ProjectCommand    : getCxProjects: found 1 matching projects
2022-12-15 08:24:14.221  INFO 11816 --- [           main] com.checkmarx.sdk.service.CxService      : Creating branched project with name 'DSVW-branch1' from existing project with ID 18
2022-12-15 08:24:15.564 DEBUG 11816 --- [           main] com.checkmarx.sdk.service.CxService      : Waiting for branching to complete for project 35
2022-12-15 08:24:15.564 DEBUG 11816 --- [           main] com.checkmarx.sdk.service.CxService      : Retrieving branching status of project 35
2022-12-15 08:24:16.116 DEBUG 11816 --- [           main] com.checkmarx.sdk.service.CxService      : Response payload is not JSON. Assuming a version of SAST that does not support the GET /projects/branch/{id} API
2022-12-15 08:24:16.116 DEBUG 11816 --- [           main] com.checkmarx.sdk.service.CxService      : Unable to retrieve project branching status
2022-12-15 08:24:21.121  INFO 11816 --- [           main] com.checkmarx.util.cmd.ProjectCommand    : branch: ID of branch project: 35
```

CxJavautil command log for CxSAST 9.5:

```
$ java -jar build/libs/cx-java-util-0.5.0-SNAPSHOT.jar project branch -t CxServer NodeGoat NodeGoat-branch

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::                (v2.7.6)

2022-12-15 09:07:46.832  INFO 13936 --- [           main] c.c.util.CheckmarxUtilApplication        : Starting CheckmarxUtilApplication using Java 1.8.0_282 on JamesB-Laptop with PID 13936 (C:\Users\JamesBo\Documents\src\checkmarx-ts\cx-java-util\build\libs\cx-java-util-0.5.0-SNAPSHOT.jar started by JamesBo in C:\Users\JamesBo\Documents\src\checkmarx-ts\cx-java-util)
2022-12-15 09:07:46.835 DEBUG 13936 --- [           main] c.c.util.CheckmarxUtilApplication        : Running with Spring Boot v2.7.6, Spring v5.3.24
2022-12-15 09:07:46.836  INFO 13936 --- [           main] c.c.util.CheckmarxUtilApplication        : No active profile set, falling back to 1 default profile: "default"
2022-12-15 09:07:50.352  INFO 13936 --- [           main] o.s.ws.soap.saaj.SaajSoapMessageFactory  : Creating SAAJ 1.3 MessageFactory with SOAP 1.1 Protocol
2022-12-15 09:07:51.728  INFO 13936 --- [           main] c.c.util.CheckmarxUtilApplication        : Started CheckmarxUtilApplication in 5.438 seconds (JVM running for 6.003)
2022-12-15 09:07:51.730 DEBUG 13936 --- [           main] com.checkmarx.util.CheckmarxUtilRunner   : run: starting
2022-12-15 09:07:51.878  INFO 13936 --- [           main] com.checkmarx.util.cmd.ProjectCommand    : Calling project branch command: project: NodeGoat, branch: NodeGoat-branch
2022-12-15 09:07:51.879 DEBUG 13936 --- [           main] com.checkmarx.util.cmd.ProjectCommand    : getCxProjects: project: NodeGoat, team: CxServer
2022-12-15 09:07:51.879 DEBUG 13936 --- [           main] com.checkmarx.util.cmd.ProjectCommand    : getCxProjects: project: NodeGoat, team: CxServer
2022-12-15 09:07:51.885  INFO 13936 --- [           main] com.checkmarx.sdk.service.CxAuthService  : Logging into Checkmarx http://172.35.1.164/cxrestapi/auth/identity/connect/token
2022-12-15 09:07:52.648  INFO 13936 --- [           main] com.checkmarx.sdk.service.CxService      : Retrieving Cx teams
2022-12-15 09:07:52.903 DEBUG 13936 --- [           main] com.checkmarx.util.cmd.ProjectCommand    : getTeamId: found team /CxServer with ID 1
2022-12-15 09:07:53.463 DEBUG 13936 --- [           main] com.checkmarx.util.cmd.ProjectCommand    : getCxProjects: found 1 matching projects
2022-12-15 09:07:53.465  INFO 13936 --- [           main] com.checkmarx.sdk.service.CxService      : Creating branched project with name 'NodeGoat-branch' from existing project with ID 1
2022-12-15 09:07:54.008 DEBUG 13936 --- [           main] com.checkmarx.sdk.service.CxService      : Waiting for branching to complete for project 10
2022-12-15 09:07:54.008 DEBUG 13936 --- [           main] com.checkmarx.sdk.service.CxService      : Retrieving branching status of project 10
2022-12-15 09:07:54.277 DEBUG 13936 --- [           main] com.checkmarx.sdk.service.CxService      : Branching status is 0 (Started)
2022-12-15 09:07:59.290 DEBUG 13936 --- [           main] com.checkmarx.sdk.service.CxService      : Retrieving branching status of project 10
2022-12-15 09:07:59.549 DEBUG 13936 --- [           main] com.checkmarx.sdk.service.CxService      : Branching status is 2 (Completed)
2022-12-15 09:07:59.549  INFO 13936 --- [           main] com.checkmarx.util.cmd.ProjectCommand    : branch: ID of branch project: 10
```