### PR TITLE
Pr cxflw 662 prenpostactionissue sdk Fix for SAST 9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 
 
-	<version>0.5.46</version>
+	<version>0.5.47</version>
 
 
 	<name>cx-spring-boot-sdk</name>

--- a/src/main/java/com/checkmarx/sdk/dto/cx/preandpostaction/ScanSettings.java
+++ b/src/main/java/com/checkmarx/sdk/dto/cx/preandpostaction/ScanSettings.java
@@ -1,6 +1,8 @@
 package com.checkmarx.sdk.dto.cx.preandpostaction;
 
 import com.checkmarx.sdk.dto.cx.CxEmailNotifications;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
@@ -42,6 +44,7 @@ Root root = om.readValue(myJsonString, Root.class); */
     public Link link;
 }
 
+@JsonIgnoreProperties(value = { "postScanActionConditions","postScanActionArguments" })
 public class ScanSettings{
     public Project project;
     public Preset preset;
@@ -56,6 +59,8 @@ public class ScanSettings{
 
     @Getter
     public String postScanActionName;
+
+
 }
 
 

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -2124,7 +2124,6 @@ public class CxService implements CxClient {
             }
             CustomTaskByName customTaskDetais = new CustomTaskByName();
 
-
                 customTaskDetais = getPreActionID(scanSettingsDetails.getPostScanActionName());
 
                 if(params.getEmailNotifications()==null){
@@ -2138,8 +2137,13 @@ public class CxService implements CxClient {
                 createScanSetting(projectId, presetId, engineConfigurationId, cxProperties.getPostActionPostbackId(),
                         params.getEmailNotifications());
             }else{
-                createScanSetting(projectId, presetId, engineConfigurationId, customTaskDetais.getId(),
-                        params.getEmailNotifications());
+                if(customTaskDetais!=null){
+                    createScanSetting(projectId, presetId, engineConfigurationId, customTaskDetais.getId(),
+                            params.getEmailNotifications());
+                }else{
+                    createScanSetting(projectId, presetId, engineConfigurationId, cxProperties.getPostActionPostbackId(),
+                            params.getEmailNotifications());
+                }
             }
 
             setProjectExcludeDetails(projectId, params.getFolderExclude(), params.getFileExclude());
@@ -2208,7 +2212,8 @@ public class CxService implements CxClient {
             String response = restTemplate.postForObject(cxProperties.getUrl().concat(SCAN), requestEntity, String.class);
             JSONObject obj = new JSONObject(response);
             String id = obj.get("id").toString();
-            log.info("Scan created with Id {} for project Id {}", id, projectId);
+            log.info("Scan created with Id {} for project Id Satyam {}", id, projectId);
+            System.err.println("cxflowscanidextractiongithubaction " +id+ "endofstatementscanidaction");
             return Integer.parseInt(id);
         } catch (HttpStatusCodeException e) {
             log.error(SCAN_CREATION_ERROR, projectId, e.getStatusCode());

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -1992,7 +1992,7 @@ public class CxService implements CxClient {
 
     @Override
     public CustomTaskByName getPreActionID(String name) {
-        if(name.equalsIgnoreCase("")){
+        if(name == null || name.equalsIgnoreCase("")){
             return null;
         }
         return scanSettingsClient.getPreActionID(name);
@@ -2118,6 +2118,7 @@ public class CxService implements CxClient {
             ObjectMapper mapper = new ObjectMapper();
             try {
                 scanSettingsDetails = mapper.readValue(preAndPostAction, ScanSettings.class);
+
             } catch (JsonProcessingException e) {
                 log.debug("Json Parsing Excption for pre and post action settings {}",e.getMessage());
             }
@@ -2133,7 +2134,7 @@ public class CxService implements CxClient {
             if(params.getPostBackActionId()!=null){
                 createScanSetting(projectId, presetId, engineConfigurationId, params.getPostBackActionId(),
                         params.getEmailNotifications());
-            }else if(cxProperties.getPostActionPostbackId() != null){
+            }else if(cxProperties.getPostActionPostbackId() != null && cxProperties.getPostActionPostbackId() != 0){
                 createScanSetting(projectId, presetId, engineConfigurationId, cxProperties.getPostActionPostbackId(),
                         params.getEmailNotifications());
             }else{

--- a/src/main/java/com/checkmarx/sdk/service/ScanSettingsClientImpl.java
+++ b/src/main/java/com/checkmarx/sdk/service/ScanSettingsClientImpl.java
@@ -70,7 +70,8 @@ public class ScanSettingsClientImpl implements ScanSettingsClient {
                 .presetId(presetId)
                 .emailNotifications(emailNotifications)
                 .build();
-        if(postActionId != 0){
+        log.info("Post back action ID : {} ",postActionId);
+        if(postActionId != 0 ){
             scanSettings.setPostScanActionId(postActionId);
         }
             //  else{


### PR DESCRIPTION
In this we have done changes to support SAST 9.5 because with 9.5 payload response has additional properties which was not needed so we have ignored those properties.