### PR TITLE
Handle race condition when creating a project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.5.49</version>
+	<version>0.5.50</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>


### PR DESCRIPTION
It is possible that two CxFlow processes, running in parallel, will both try to create the same project. This happens because the checking whether the project exists, and the creation of the new project in the case that the project does not exist, do not happen as an atomic action. So, both CxFlow processes may believe that the project does not already exist, but only one will be able to successfully create it. The other process will receive a 400 (Bad Request) response indicating that the project already exists. In the latter case, this PR causes CxFlow to retrieve the existing project's identifier and return it.

This PR addresses https://github.com/checkmarx-ltd/checkmarx-spring-boot-java-sdk/issues/318. and https://github.com/checkmarx-ltd/checkmarx-spring-boot-java-sdk/pull/322