### PR TITLE
Remove "Satyam" from log message

### DIFF
--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -2235,7 +2235,7 @@ public class CxService implements CxClient {
             String response = restTemplate.postForObject(cxProperties.getUrl().concat(SCAN), requestEntity, String.class);
             JSONObject obj = new JSONObject(response);
             String id = obj.get("id").toString();
-            log.info("Scan created with Id {} for project Id Satyam {}", id, projectId);
+            log.info("Scan created with Id {} for project Id {}", id, projectId);
             System.err.println("cxflowscanidextractiongithubaction " +id+ "endofstatementscanidaction");
             return Integer.parseInt(id);
         } catch (HttpStatusCodeException e) {


### PR DESCRIPTION
A stray "Satyam" was added to a log message in commit 4126e065 (presumably for debugging purposes). This PR removes it.

This PR addresses the following issue raised against the Checkmarx CxFlow GitHub Action: https://github.com/checkmarx-ts/checkmarx-cxflow-github-action/issues/65