### PR TITLE
Base project of branched project correct configuration fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.5.50</version>
+	<version>0.5.51</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -2076,13 +2076,13 @@ public class CxService implements CxClient {
         String teamId = determineTeamId(params);
         Integer projectId = determineProjectId(params, teamId);
         boolean projectExistedBeforeScan = !projectId.equals(UNKNOWN_INT);
+        Integer baseProjectId = UNKNOWN_INT;
         if (!projectExistedBeforeScan) {
             /*
                 When CxBranch is set to true, the current and default branches are compared if they are same then a licensed project is created,
                 if they are not same then, the ID of the default or base project is retrieved to create a branch project for the current branch of the repo,
                 if a project for default branch is not present then it is first created and then a branched project is created from it.
              */
-            Integer baseProjectId;
             String derivedProjectName = "";
             if(cxProperties.getCxBranch()){
                 if(!params.getBranch().equals(params.getDefaultBranch())) {
@@ -2156,15 +2156,23 @@ public class CxService implements CxClient {
             if(params.getPostBackActionId()!=null){
                 createScanSetting(projectId, presetId, engineConfigurationId, params.getPostBackActionId(),
                         params.getEmailNotifications());
+                createScanSetting(baseProjectId, presetId, engineConfigurationId, params.getPostBackActionId(),
+                        params.getEmailNotifications());
             }else if(cxProperties.getPostActionPostbackId() != null && cxProperties.getPostActionPostbackId() != 0){
                 createScanSetting(projectId, presetId, engineConfigurationId, cxProperties.getPostActionPostbackId(),
+                        params.getEmailNotifications());
+                createScanSetting(baseProjectId, presetId, engineConfigurationId, cxProperties.getPostActionPostbackId(),
                         params.getEmailNotifications());
             }else{
                 if(customTaskDetais!=null){
                     createScanSetting(projectId, presetId, engineConfigurationId, customTaskDetais.getId(),
                             params.getEmailNotifications());
+                    createScanSetting(baseProjectId, presetId, engineConfigurationId, customTaskDetais.getId(),
+                            params.getEmailNotifications());
                 }else{
                     createScanSetting(projectId, presetId, engineConfigurationId, cxProperties.getPostActionPostbackId(),
+                            params.getEmailNotifications());
+                    createScanSetting(baseProjectId, presetId, engineConfigurationId, cxProperties.getPostActionPostbackId(),
                             params.getEmailNotifications());
                 }
             }


### PR DESCRIPTION
CxFlow has the ability to create branched projects in CxSAST. If this functionality is enabled (by setting the checkmarx.cx-branch property to true), then, if the --branch and --default-branch command line arguments have different values, CxFlow creates a branched project (assuming the project specified on the command line does not already exist). When creating a branched project, CxFlow first checks whether the base project exists and, if it does not, creates it.

However, when it creates the base project, it does not update the base project's scan settings, leading to an inconsistency between the base and branched projects.

https://github.com/checkmarx-ltd/cx-flow/issues/1048