### PR TITLE
CXFLW-877 Added code for Scan Left Active Status

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.5.51</version>
+	<version>0.5.52</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -81,6 +81,11 @@ public class CxProperties extends CxPropertiesBase{
      */
     private Boolean disableClubbing = false;
 
+    @Getter
+    @Setter
+    private Boolean infiniteTimeOutCheckflag = true; // Adding this if any issue occurs user can turn off this check and it will not affect original
+
+
     /**
      * Maps finding state ID (as returned in CxSAST report) to state name (as specified in filter configuration).
      */

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -2841,6 +2841,11 @@ public class CxService implements CxClient {
                     !status.equals(CxService.SCAN_STATUS_FAILED)) {
                 Thread.sleep(cxProperties.getScanPolling());
                 status = getScanStatus(scanId);
+
+                if(status.equals(CxService.UNKNOWN_INT) && cxProperties.getInfiniteTimeOutCheckflag()){
+                    break;
+                }
+
                 timer += cxProperties.getScanPolling();
 
                 //Scan Queuing Timeout = '0' and Scan Queuing = true would be waiting forever with the scan in the queue
@@ -2859,6 +2864,11 @@ public class CxService implements CxClient {
             if (status.equals(CxService.SCAN_STATUS_FAILED)) {
                 throw new CheckmarxException("Scan was failed");
             }
+
+            if(status.equals(CxService.UNKNOWN_INT) && cxProperties.getInfiniteTimeOutCheckflag()){
+                throw new CheckmarxException("Scan was failed");
+            }
+
             if (status.equals(CxService.SCAN_STATUS_CANCELED)) {
                 throw new CheckmarxException("Scan was cancelled");
             }


### PR DESCRIPTION
Description

If someone has postponed existing scan checking status returns -1 which causes while loop to run for infinite time and causes customer to wait till timeout.

Steps to Reproduce

Create scan using cx-flow and while scan in progress just postpone the scan. Cx-flow will wait for result till timeout and then throws exception.
Actual Result

Cx-flow waiting for result till timeout and then throws exception.
Expected Result

It should throw exception immediately not after defined timeout
Possible solution

Code change required