### PR TITLE
Prevent local source deletion

### DIFF
--- a/src/main/java/com/checkmarx/sdk/dto/SourceLocationType.java
+++ b/src/main/java/com/checkmarx/sdk/dto/SourceLocationType.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum SourceLocationType {
     LOCAL_DIRECTORY("upload"),
-    REMOTE_REPOSITORY("git");
+    REMOTE_REPOSITORY("git"),
+    CLONED_REMOTE_REPOSITORY("cloned");
 
     /**
      * Value used in API calls. Currently all the clients using this enum use the same API values.

--- a/src/main/java/com/checkmarx/sdk/service/scanner/AbstractScanner.java
+++ b/src/main/java/com/checkmarx/sdk/service/scanner/AbstractScanner.java
@@ -83,16 +83,20 @@ public abstract class AbstractScanner  {
         setRemoteBranch(scanParams, remoteRepoInfo);
 
         if (localSourcesAreSpecified(scanParams)) {
-            configBase.setSourceLocationType(SourceLocationType.LOCAL_DIRECTORY);
+            configBase.setSourceLocationType(SourceLocationType.CLONED_REMOTE_REPOSITORY);           
             // If both zip file and source directory are specified, zip file has priority.
-            // This is to conform to Common Client behavior.
+            // This is to conform to Common Client behavior.     
             if (StringUtils.isNotEmpty(scanParams.getZipPath())) {
                 log.debug("Using a local zip file for scanning.");
                 scanConfig.setZipFile(new File(scanParams.getZipPath()));
-            } else {
-                log.debug("Using a local directory for scanning.");
+            } else if (scanParams.getRemoteRepoUrl() != null) {
+                log.debug("Using a cloned local directory for scanning.");
                 scanConfig.setSourceDir(scanParams.getSourceDir());
-            }
+            } else {
+                log.debug("Using a local directory for scanning.");                    
+                configBase.setSourceLocationType(SourceLocationType.LOCAL_DIRECTORY);          
+                scanConfig.setSourceDir(scanParams.getSourceDir());
+            } 
         } else {
             configBase.setSourceLocationType(SourceLocationType.REMOTE_REPOSITORY);
             remoteRepoInfo.setUrl(scanParams.getRemoteRepoUrl());

--- a/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
+++ b/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
@@ -372,9 +372,12 @@ public class ScaClientHelper extends ScanClientHelper implements IScanClientHelp
             throw new CxHTTPClientException("Error while running sca resolver executable. Exit code: "+exitCode);
         }
         finally {
-            log.debug("deleting all files ");
-            log.debug("clone path :{}",file.toPath());
-            cxRepoFileHelper.deleteCloneLocalDir(file);
+            if (scaConfig.getSourceLocationType() != SourceLocationType.LOCAL_DIRECTORY) {
+                // consider this a cloned source directory and delete it
+                log.debug("deleting all files ");
+                log.debug("clone path :{}",file.toPath());
+                cxRepoFileHelper.deleteCloneLocalDir(file);
+            }
             log.debug("result path :{}",resultFilePath.getParentFile());
             FileUtils.deleteDirectory(resultFilePath.getParentFile());
             if(sastResultFile!=null )


### PR DESCRIPTION
Previous functionality was deleting local source directories specified by the --f scan parameter.  
- Added a third distinction of source location representing a cloned remote directory
- Modified calculation of source location type
- Prevented deletion of non-cloned local source directories

