### PR TITLE
Prevent ScaResolver for deletion of local source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.5.52</version>
+	<version>0.5.53</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/dto/SourceLocationType.java
+++ b/src/main/java/com/checkmarx/sdk/dto/SourceLocationType.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum SourceLocationType {
     LOCAL_DIRECTORY("upload"),
-    REMOTE_REPOSITORY("git");
+    REMOTE_REPOSITORY("git"),
+    CLONED_REMOTE_REPOSITORY("cloned");
 
     /**
      * Value used in API calls. Currently all the clients using this enum use the same API values.

--- a/src/main/java/com/checkmarx/sdk/service/scanner/AbstractScanner.java
+++ b/src/main/java/com/checkmarx/sdk/service/scanner/AbstractScanner.java
@@ -83,14 +83,18 @@ public abstract class AbstractScanner  {
         setRemoteBranch(scanParams, remoteRepoInfo);
 
         if (localSourcesAreSpecified(scanParams)) {
-            configBase.setSourceLocationType(SourceLocationType.LOCAL_DIRECTORY);
+            configBase.setSourceLocationType(SourceLocationType.CLONED_REMOTE_REPOSITORY);
             // If both zip file and source directory are specified, zip file has priority.
             // This is to conform to Common Client behavior.
             if (StringUtils.isNotEmpty(scanParams.getZipPath())) {
                 log.debug("Using a local zip file for scanning.");
                 scanConfig.setZipFile(new File(scanParams.getZipPath()));
-            } else {
+            } else if (scanParams.getRemoteRepoUrl() != null) {
+                log.debug("Using a cloned local directory for scanning.");
+                scanConfig.setSourceDir(scanParams.getSourceDir());
+            }else {
                 log.debug("Using a local directory for scanning.");
+                configBase.setSourceLocationType(SourceLocationType.LOCAL_DIRECTORY);
                 scanConfig.setSourceDir(scanParams.getSourceDir());
             }
         } else {

--- a/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
+++ b/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
@@ -373,8 +373,10 @@ public class ScaClientHelper extends ScanClientHelper implements IScanClientHelp
         }
         finally {
             log.debug("deleting all files ");
-            log.debug("clone path :{}",file.toPath());
-            cxRepoFileHelper.deleteCloneLocalDir(file);
+            if (scaConfig.getSourceLocationType().equals(SourceLocationType.CLONED_REMOTE_REPOSITORY)) {
+                log.debug("clone path :{}",file.toPath());
+                cxRepoFileHelper.deleteCloneLocalDir(file);
+            }
             log.debug("result path :{}",resultFilePath.getParentFile());
             FileUtils.deleteDirectory(resultFilePath.getParentFile());
             if(sastResultFile!=null )


### PR DESCRIPTION
Previous functionality was deleting local source directories specified by the --f scan parameter.

- Added a third distinction of source location representing a cloned remote directory
- Modified calculation of source location type
- Prevented deletion of non-cloned local source directories