### PR TITLE
CXFLW-913 SCA Testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.5.56</version>
+	<version>0.5.59</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.5.59</version>
+	<version>0.5.57</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/config/ScaProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/ScaProperties.java
@@ -39,6 +39,10 @@ public class ScaProperties {
     private String filterPolicyViolation;
     private String filterdependencytype;
     private boolean filterOutDevdependency=false;
+    private boolean filterOutDirectDependency=false;
+    private boolean filterOutPluginDependency=false;
+    private boolean filterOutTestDependency=false;
+    private boolean filterOutNpmVerifiedDependency=false;
     private boolean enableScaResolver;
     private String pathToScaResolver="/app";
     private Map<String,String> scaResolverAddParameters;

--- a/src/main/java/com/checkmarx/sdk/dto/sca/report/Package.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/report/Package.java
@@ -45,5 +45,7 @@ public class Package implements Serializable {
     //public boolean isDirectDependency;
     @JsonProperty(value="isDevelopment")
     private boolean IsDevelopmentDependency;
+    @JsonProperty(value="isTestDependency")
+    private boolean IsTestDependency;
     private PackageUsage packageUsage;
 }

--- a/src/main/java/com/checkmarx/sdk/service/scanner/ScaScanner.java
+++ b/src/main/java/com/checkmarx/sdk/service/scanner/ScaScanner.java
@@ -41,14 +41,30 @@ public class ScaScanner extends AbstractScanner {
         EngineFilterConfiguration filterConfig = extractFilterConfigFrom(scanParams);
 
         List<Finding> findingsToRetain = new ArrayList<>();
-        
-        combinedResults.getScaResults()
-                .getFindings().forEach(finding -> {
-                    if(passesFilter(finding, filterConfig)){
-                        findingsToRetain.add(finding);
-                    }
-        });
+        if (scaProperties.isFilterOutDevdependency()) {
+            List<String> packageIds = new ArrayList<>();
+            combinedResults.getScaResults()
+                    .getPackages().forEach(packages -> {
+                        if (packages.isIsDevelopmentDependency() || packages.isIsTestDependency()) {
+                            packageIds.add(packages.getId());
+                        }
+                    });
 
+            combinedResults.getScaResults()
+                    .getFindings().forEach(finding -> {
+                        if (passesFilter(finding, filterConfig) && !packageIds.contains(finding.getPackageId())) {
+                            findingsToRetain.add(finding);
+                        }
+                    });
+
+        }else{
+            combinedResults.getScaResults()
+                    .getFindings().forEach(finding -> {
+                        if(passesFilter(finding, filterConfig)){
+                            findingsToRetain.add(finding);
+                        }
+                    });
+        }
         combinedResults.getScaResults().setFindings(findingsToRetain);
                 
     }


### PR DESCRIPTION
Description

We have feature to filter out development dependencies of SCA results at the time to counting thresholds for break build but in same way user wants for different bug trackers issues or Jira tickets should not be created for dev dependency and if we have filter enabled and dev dependency already in bug trackers it should close that issue or Jira ticket

 

PM Notes:

The customer wants to exclude the indirect dependencies. (requested from account Dunnhumby)