### PR TITLE
Filter out development dependencies from the SCA results. Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.5.61</version>
+	<version>0.5.63</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/service/scanner/ScaScanner.java
+++ b/src/main/java/com/checkmarx/sdk/service/scanner/ScaScanner.java
@@ -41,7 +41,7 @@ public class ScaScanner extends AbstractScanner {
         EngineFilterConfiguration filterConfig = extractFilterConfigFrom(scanParams);
 
         List<Finding> findingsToRetain = new ArrayList<>();
-        if (scaProperties.isFilterOutDevdependency()) {
+        if (scaProperties.isFilterOutDevdependency() && !scaProperties.isFilterOutInDirectDependency()) {
             List<String> packageIds = new ArrayList<>();
             combinedResults.getScaResults()
                     .getPackages().forEach(packages -> {
@@ -57,11 +57,26 @@ public class ScaScanner extends AbstractScanner {
                         }
                     });
 
-        }else if(scaProperties.isFilterOutInDirectDependency()){
+        }else if(scaProperties.isFilterOutInDirectDependency() && !scaProperties.isFilterOutDevdependency()){
             List<String> packageIds = new ArrayList<>();
             combinedResults.getScaResults()
                     .getPackages().forEach(packages -> {
                         if (packages.isIsDirectDependency()) {
+                            packageIds.add(packages.getId());
+                        }
+                    });
+            //Adding condition for only directdependency.
+            combinedResults.getScaResults()
+                    .getFindings().forEach(finding -> {
+                        if (passesFilter(finding, filterConfig) && packageIds.contains(finding.getPackageId())) {
+                            findingsToRetain.add(finding);
+                        }
+                    });
+        }else if(scaProperties.isFilterOutInDirectDependency() && scaProperties.isFilterOutDevdependency()){
+            List<String> packageIds = new ArrayList<>();
+            combinedResults.getScaResults()
+                    .getPackages().forEach(packages -> {
+                        if (packages.isIsDirectDependency() || !(packages.isIsDevelopmentDependency() || packages.isIsTestDependency())) {
                             packageIds.add(packages.getId());
                         }
                     });


### PR DESCRIPTION
Description

We have feature to filter out development dependencies of SCA results at the time to counting thresholds for break build but in same way user wants for different bug trackers issues or Jira tickets should not be created for dev dependency and if we have filter enabled and dev dependency already in bug trackers it should close that issue or Jira ticket

 

PM Notes:

The customer wants to exclude the indirect dependencies. (requested from account Dunnhumby)