### PR TITLE
CXFLW-916 Workflow change for submitting scans to avoid source locati…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.5.69</version>
+	<version>0.5.70</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/remotesettings/custom/Customremotemain.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/custom/Customremotemain.java
@@ -1,0 +1,68 @@
+
+package com.checkmarx.sdk.remotesettings.custom;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Customremotemain {
+
+    private String path;
+    private Integer pullingCommandId;
+    private Link link;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public Customremotemain withPath(String path) {
+        this.path = path;
+        return this;
+    }
+
+    public Integer getPullingCommandId() {
+        return pullingCommandId;
+    }
+
+    public void setPullingCommandId(Integer pullingCommandId) {
+        this.pullingCommandId = pullingCommandId;
+    }
+
+    public Customremotemain withPullingCommandId(Integer pullingCommandId) {
+        this.pullingCommandId = pullingCommandId;
+        return this;
+    }
+
+    public Link getLink() {
+        return link;
+    }
+
+    public void setLink(Link link) {
+        this.link = link;
+    }
+
+    public Customremotemain withLink(Link link) {
+        this.link = link;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Customremotemain withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/custom/Link.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/custom/Link.java
@@ -1,0 +1,54 @@
+
+package com.checkmarx.sdk.remotesettings.custom;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Link {
+
+    private String rel;
+    private String uri;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public String getRel() {
+        return rel;
+    }
+
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+    public Link withRel(String rel) {
+        this.rel = rel;
+        return this;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public Link withUri(String uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Link withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/exclude/ExcludeSettingsmain.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/exclude/ExcludeSettingsmain.java
@@ -1,0 +1,82 @@
+
+package com.checkmarx.sdk.remotesettings.exclude;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class ExcludeSettingsmain {
+
+    private Integer projectId;
+    private String excludeFoldersPattern;
+    private String excludeFilesPattern;
+    private Link link;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public Integer getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(Integer projectId) {
+        this.projectId = projectId;
+    }
+
+    public ExcludeSettingsmain withProjectId(Integer projectId) {
+        this.projectId = projectId;
+        return this;
+    }
+
+    public String getExcludeFoldersPattern() {
+        return excludeFoldersPattern;
+    }
+
+    public void setExcludeFoldersPattern(String excludeFoldersPattern) {
+        this.excludeFoldersPattern = excludeFoldersPattern;
+    }
+
+    public ExcludeSettingsmain withExcludeFoldersPattern(String excludeFoldersPattern) {
+        this.excludeFoldersPattern = excludeFoldersPattern;
+        return this;
+    }
+
+    public String getExcludeFilesPattern() {
+        return excludeFilesPattern;
+    }
+
+    public void setExcludeFilesPattern(String excludeFilesPattern) {
+        this.excludeFilesPattern = excludeFilesPattern;
+    }
+
+    public ExcludeSettingsmain withExcludeFilesPattern(String excludeFilesPattern) {
+        this.excludeFilesPattern = excludeFilesPattern;
+        return this;
+    }
+
+    public Link getLink() {
+        return link;
+    }
+
+    public void setLink(Link link) {
+        this.link = link;
+    }
+
+    public ExcludeSettingsmain withLink(Link link) {
+        this.link = link;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public ExcludeSettingsmain withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/exclude/Link.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/exclude/Link.java
@@ -1,0 +1,54 @@
+
+package com.checkmarx.sdk.remotesettings.exclude;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Link {
+
+    private String rel;
+    private String uri;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public String getRel() {
+        return rel;
+    }
+
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+    public Link withRel(String rel) {
+        this.rel = rel;
+        return this;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public Link withUri(String uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Link withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/git/Gitremotemain.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/git/Gitremotemain.java
@@ -1,0 +1,82 @@
+
+package com.checkmarx.sdk.remotesettings.git;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Gitremotemain {
+
+    private String url;
+    private String branch;
+    private Boolean useSsh;
+    private Link link;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public Gitremotemain withUrl(String url) {
+        this.url = url;
+        return this;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public void setBranch(String branch) {
+        this.branch = branch;
+    }
+
+    public Gitremotemain withBranch(String branch) {
+        this.branch = branch;
+        return this;
+    }
+
+    public Boolean getUseSsh() {
+        return useSsh;
+    }
+
+    public void setUseSsh(Boolean useSsh) {
+        this.useSsh = useSsh;
+    }
+
+    public Gitremotemain withUseSsh(Boolean useSsh) {
+        this.useSsh = useSsh;
+        return this;
+    }
+
+    public Link getLink() {
+        return link;
+    }
+
+    public void setLink(Link link) {
+        this.link = link;
+    }
+
+    public Gitremotemain withLink(Link link) {
+        this.link = link;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Gitremotemain withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/git/Link.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/git/Link.java
@@ -1,0 +1,54 @@
+
+package com.checkmarx.sdk.remotesettings.git;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Link {
+
+    private String rel;
+    private String uri;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public String getRel() {
+        return rel;
+    }
+
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+    public Link withRel(String rel) {
+        this.rel = rel;
+        return this;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public Link withUri(String uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Link withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/perforce/Link.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/perforce/Link.java
@@ -1,0 +1,54 @@
+
+package com.checkmarx.sdk.remotesettings.perforce;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Link {
+
+    private String rel;
+    private String uri;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public String getRel() {
+        return rel;
+    }
+
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+    public Link withRel(String rel) {
+        this.rel = rel;
+        return this;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public Link withUri(String uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Link withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/perforce/Perforceremotemain.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/perforce/Perforceremotemain.java
@@ -1,0 +1,83 @@
+
+package com.checkmarx.sdk.remotesettings.perforce;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Perforceremotemain {
+
+    private Uri uri;
+    private List<String> paths;
+    private String browseMode;
+    private Link link;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public Uri getUri() {
+        return uri;
+    }
+
+    public void setUri(Uri uri) {
+        this.uri = uri;
+    }
+
+    public Perforceremotemain withUri(Uri uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(List<String> paths) {
+        this.paths = paths;
+    }
+
+    public Perforceremotemain withPaths(List<String> paths) {
+        this.paths = paths;
+        return this;
+    }
+
+    public String getBrowseMode() {
+        return browseMode;
+    }
+
+    public void setBrowseMode(String browseMode) {
+        this.browseMode = browseMode;
+    }
+
+    public Perforceremotemain withBrowseMode(String browseMode) {
+        this.browseMode = browseMode;
+        return this;
+    }
+
+    public Link getLink() {
+        return link;
+    }
+
+    public void setLink(Link link) {
+        this.link = link;
+    }
+
+    public Perforceremotemain withLink(Link link) {
+        this.link = link;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Perforceremotemain withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/perforce/Uri.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/perforce/Uri.java
@@ -1,0 +1,54 @@
+
+package com.checkmarx.sdk.remotesettings.perforce;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Uri {
+
+    private String absoluteUrl;
+    private Integer port;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public String getAbsoluteUrl() {
+        return absoluteUrl;
+    }
+
+    public void setAbsoluteUrl(String absoluteUrl) {
+        this.absoluteUrl = absoluteUrl;
+    }
+
+    public Uri withAbsoluteUrl(String absoluteUrl) {
+        this.absoluteUrl = absoluteUrl;
+        return this;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public Uri withPort(Integer port) {
+        this.port = port;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Uri withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/shared/Link.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/shared/Link.java
@@ -1,0 +1,54 @@
+
+package com.checkmarx.sdk.remotesettings.shared;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Link {
+
+    private String rel;
+    private String uri;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public String getRel() {
+        return rel;
+    }
+
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+    public Link withRel(String rel) {
+        this.rel = rel;
+        return this;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public Link withUri(String uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Link withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/shared/Sharedremotemain.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/shared/Sharedremotemain.java
@@ -1,0 +1,55 @@
+
+package com.checkmarx.sdk.remotesettings.shared;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Sharedremotemain {
+
+    private List<String> paths;
+    private Link link;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(List<String> paths) {
+        this.paths = paths;
+    }
+
+    public Sharedremotemain withPaths(List<String> paths) {
+        this.paths = paths;
+        return this;
+    }
+
+    public Link getLink() {
+        return link;
+    }
+
+    public void setLink(Link link) {
+        this.link = link;
+    }
+
+    public Sharedremotemain withLink(Link link) {
+        this.link = link;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Sharedremotemain withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/svn/Link.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/svn/Link.java
@@ -1,0 +1,54 @@
+
+package com.checkmarx.sdk.remotesettings.svn;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Link {
+
+    private String rel;
+    private String uri;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public String getRel() {
+        return rel;
+    }
+
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+    public Link withRel(String rel) {
+        this.rel = rel;
+        return this;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public Link withUri(String uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Link withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/svn/Svnremotemain.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/svn/Svnremotemain.java
@@ -1,0 +1,83 @@
+
+package com.checkmarx.sdk.remotesettings.svn;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Svnremotemain {
+
+    private Uri uri;
+    private List<String> paths;
+    private Boolean useSsh;
+    private Link link;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public Uri getUri() {
+        return uri;
+    }
+
+    public void setUri(Uri uri) {
+        this.uri = uri;
+    }
+
+    public Svnremotemain withUri(Uri uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(List<String> paths) {
+        this.paths = paths;
+    }
+
+    public Svnremotemain withPaths(List<String> paths) {
+        this.paths = paths;
+        return this;
+    }
+
+    public Boolean getUseSsh() {
+        return useSsh;
+    }
+
+    public void setUseSsh(Boolean useSsh) {
+        this.useSsh = useSsh;
+    }
+
+    public Svnremotemain withUseSsh(Boolean useSsh) {
+        this.useSsh = useSsh;
+        return this;
+    }
+
+    public Link getLink() {
+        return link;
+    }
+
+    public void setLink(Link link) {
+        this.link = link;
+    }
+
+    public Svnremotemain withLink(Link link) {
+        this.link = link;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Svnremotemain withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/svn/Uri.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/svn/Uri.java
@@ -1,0 +1,54 @@
+
+package com.checkmarx.sdk.remotesettings.svn;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Uri {
+
+    private String absoluteUrl;
+    private Integer port;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public String getAbsoluteUrl() {
+        return absoluteUrl;
+    }
+
+    public void setAbsoluteUrl(String absoluteUrl) {
+        this.absoluteUrl = absoluteUrl;
+    }
+
+    public Uri withAbsoluteUrl(String absoluteUrl) {
+        this.absoluteUrl = absoluteUrl;
+        return this;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public Uri withPort(Integer port) {
+        this.port = port;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Uri withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/tfs/Link.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/tfs/Link.java
@@ -1,0 +1,54 @@
+
+package com.checkmarx.sdk.remotesettings.tfs;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Link {
+
+    private String rel;
+    private String uri;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public String getRel() {
+        return rel;
+    }
+
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+    public Link withRel(String rel) {
+        this.rel = rel;
+        return this;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public Link withUri(String uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Link withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/tfs/Tfsremotemain.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/tfs/Tfsremotemain.java
@@ -1,0 +1,69 @@
+
+package com.checkmarx.sdk.remotesettings.tfs;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Tfsremotemain {
+
+    private Uri uri;
+    private List<String> paths;
+    private Link link;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public Uri getUri() {
+        return uri;
+    }
+
+    public void setUri(Uri uri) {
+        this.uri = uri;
+    }
+
+    public Tfsremotemain withUri(Uri uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(List<String> paths) {
+        this.paths = paths;
+    }
+
+    public Tfsremotemain withPaths(List<String> paths) {
+        this.paths = paths;
+        return this;
+    }
+
+    public Link getLink() {
+        return link;
+    }
+
+    public void setLink(Link link) {
+        this.link = link;
+    }
+
+    public Tfsremotemain withLink(Link link) {
+        this.link = link;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Tfsremotemain withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/remotesettings/tfs/Uri.java
+++ b/src/main/java/com/checkmarx/sdk/remotesettings/tfs/Uri.java
@@ -1,0 +1,54 @@
+
+package com.checkmarx.sdk.remotesettings.tfs;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("jsonschema2pojo")
+public class Uri {
+
+    private String absoluteUrl;
+    private Integer port;
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    public String getAbsoluteUrl() {
+        return absoluteUrl;
+    }
+
+    public void setAbsoluteUrl(String absoluteUrl) {
+        this.absoluteUrl = absoluteUrl;
+    }
+
+    public Uri withAbsoluteUrl(String absoluteUrl) {
+        this.absoluteUrl = absoluteUrl;
+        return this;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public Uri withPort(Integer port) {
+        this.port = port;
+        return this;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Uri withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+}

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -16,6 +16,13 @@ import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
 import com.checkmarx.sdk.dto.filtering.FilterInput;
 import com.checkmarx.sdk.exception.CheckmarxException;
 import com.checkmarx.sdk.exception.InvalidCredentialsException;
+import com.checkmarx.sdk.remotesettings.custom.Customremotemain;
+import com.checkmarx.sdk.remotesettings.exclude.ExcludeSettingsmain;
+import com.checkmarx.sdk.remotesettings.git.Gitremotemain;
+import com.checkmarx.sdk.remotesettings.perforce.Perforceremotemain;
+import com.checkmarx.sdk.remotesettings.shared.Sharedremotemain;
+import com.checkmarx.sdk.remotesettings.svn.Svnremotemain;
+import com.checkmarx.sdk.remotesettings.tfs.Tfsremotemain;
 import com.checkmarx.sdk.service.scanner.CxClient;
 import com.checkmarx.sdk.utils.CxRepoFileHelper;
 import com.checkmarx.sdk.utils.ScanUtils;
@@ -112,6 +119,13 @@ public class CxService implements CxClient {
     private static final String ODATA_SCAN_SIMILARITY_IDS = "/cxwebinterface/odata/v1/Scans({id})?$select=Id&$expand=Results($select=SimilarityId)";
     private static final String PROJECTS = "/projects";
     private static final String PROJECT = "/projects/{id}";
+    private static final String GIT_PROJ_DETAILS = "/projects/{id}/sourceCode/remoteSettings/git";
+    private static final String SVN_PROJ_DETAILS = "/projects/{id}/sourceCode/remoteSettings/svn";
+    private static final String TFS_PROJ_DETAILS = "/projects/{id}/sourceCode/remoteSettings/tfs";
+    private static final String EXCULDESETTINGS_PROJ_DETAILS = "/projects/{id}/sourceCode/excludeSettings";
+    private static final String CUSTOM_PROJ_DETAILS = "/projects/{id}/sourceCode/remoteSettings/custom";
+    private static final String SHARED_PROJ_DETAILS = "/projects/{id}/sourceCode/remoteSettings/shared";
+    private static final String PERFORCE_PROJ_DETAILS = "/projects/{id}/sourceCode/remoteSettings/perforce";
     private static final String PROJECT_BRANCH = "/projects/{id}/branch";
     private static final String PROJECT_BRANCH_STATUS = "/projects/branch/{id}";
     private static final String PROJECT_SOURCE = "/projects/{id}/sourceCode/remoteSettings/git";
@@ -2170,6 +2184,15 @@ public class CxService implements CxClient {
         Integer projectId = determineProjectId(params, teamId);
         boolean projectExistedBeforeScan = !projectId.equals(UNKNOWN_INT);
         Integer baseProjectId = UNKNOWN_INT;
+        //preserving settings
+        Gitremotemain gitremotemainObj = getGitRepoDetails(projectId);
+        Customremotemain customremotemainObj = getCustomRepoDetails(projectId);
+        Perforceremotemain perforceremotemainObj = getPerforceRepoDetails(projectId);
+        Sharedremotemain sharedremotemainObj = getSharedRepoDetails(projectId);
+        Svnremotemain svnremotemainObj = getSvnRepoDetails(projectId);
+        Tfsremotemain tfsremotemainObj = getTfsRepoDetails(projectId);
+        ExcludeSettingsmain excludeSettingsmainObj = getExcludeSettingsDetails(projectId);
+
         if (!projectExistedBeforeScan) {
             /*
                 When CxBranch is set to true, the current and default branches are compared if they are same then a licensed project is created,
@@ -2349,7 +2372,36 @@ public class CxService implements CxClient {
                 updateProjectCustomFields(cxProject);
             }
         }
+
+
+
+
         prepareSources(params, projectId);
+        //Setting Remembered Git Settings
+        if (gitremotemainObj != null) {
+            setGitRepoDetails(gitremotemainObj, projectId);
+        }
+        if (customremotemainObj != null) {
+            setCustomRepoDetails(customremotemainObj, projectId);
+        }
+        if (perforceremotemainObj != null) {
+            setPerforceRepoDetails(perforceremotemainObj, projectId);
+        }
+        if (sharedremotemainObj != null) {
+            setSharedRepoDetails(sharedremotemainObj, projectId);
+        }
+        if (svnremotemainObj != null) {
+            setSvnRepoDetails(svnremotemainObj, projectId);
+        }
+        if (tfsremotemainObj != null) {
+            setTfsRepoDetails(tfsremotemainObj, projectId);
+        }
+
+        if (excludeSettingsmainObj != null) {
+            setExcludeSettingsDetails(excludeSettingsmainObj, projectId);
+        }
+
+
         if(params.isIncremental() && projectExistedBeforeScan) {
             LocalDateTime scanDate = getLastScanDate(projectId);
             if(scanDate == null || LocalDateTime.now().isAfter(scanDate.plusDays(cxProperties.getIncrementalThreshold()))){
@@ -2399,10 +2451,179 @@ public class CxService implements CxClient {
                 FileUtils.deleteQuietly(new File(params.getFilePath()));
             }
         }
+
+
         log.info("...Finished creating scan");
         return UNKNOWN_INT;
     }
 
+    private void setExcludeSettingsDetails(ExcludeSettingsmain excludeSettingsmainObj, Integer projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(excludeSettingsmainObj,authClient.createAuthHeaders());
+        try {
+            log.info("Setting Exclude Settings Repo Details for project id {}", projectId);
+            restTemplate.exchange(cxProperties.getUrl().concat(EXCULDESETTINGS_PROJ_DETAILS), HttpMethod.PUT, requestEntity, String.class, projectId);
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Setting Exclude Settings Repo Details for project id {}.", projectId);
+        }
+    }
+
+    private ExcludeSettingsmain getExcludeSettingsDetails(Integer projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(authClient.createAuthHeaders());
+        try {
+            log.info("Getting Exclude Settings Details for project id {}", projectId);
+            ResponseEntity<ExcludeSettingsmain> response =restTemplate.exchange(cxProperties.getUrl().concat(EXCULDESETTINGS_PROJ_DETAILS), HttpMethod.GET, requestEntity, ExcludeSettingsmain.class, projectId);
+            return response.getBody();
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Getting Exclude Settings Details for project id {}.", projectId);
+            return null;
+        }
+    }
+
+    private void setTfsRepoDetails(Tfsremotemain tfsremotemainObj, Integer projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(tfsremotemainObj,authClient.createAuthHeaders());
+        try {
+            log.info("Setting TFS Repo Details for project id {}", projectId);
+            restTemplate.exchange(cxProperties.getUrl().concat(TFS_PROJ_DETAILS), HttpMethod.POST, requestEntity, String.class, projectId);
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Setting TFS Repo Details for project id {}.", projectId);
+        }
+    }
+
+    private void setSvnRepoDetails(Svnremotemain svnremotemainObj, Integer projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(svnremotemainObj,authClient.createAuthHeaders());
+        try {
+            log.info("Setting SVN Repo Details for project id {}", projectId);
+            restTemplate.exchange(cxProperties.getUrl().concat(SVN_PROJ_DETAILS), HttpMethod.POST, requestEntity, String.class, projectId);
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Setting SVN Repo Details for project id {}.", projectId);
+        }
+    }
+
+    private void setSharedRepoDetails(Sharedremotemain sharedremotemainObj, Integer projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(sharedremotemainObj,authClient.createAuthHeaders());
+        try {
+            log.info("Setting Shared Repo Details for project id {}", projectId);
+            restTemplate.exchange(cxProperties.getUrl().concat(SHARED_PROJ_DETAILS), HttpMethod.POST, requestEntity, String.class, projectId);
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Setting Shared Repo Details for project id {}.", projectId);
+        }
+    }
+
+    private void setPerforceRepoDetails(Perforceremotemain perforceremotemainObj, Integer projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(perforceremotemainObj,authClient.createAuthHeaders());
+        try {
+            log.info("Setting Perforce Repo Details for project id {}", projectId);
+            restTemplate.exchange(cxProperties.getUrl().concat(PERFORCE_PROJ_DETAILS), HttpMethod.POST, requestEntity, String.class, projectId);
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Setting Perforce Repo Details for project id {}.", projectId);
+        }
+    }
+
+    private void setCustomRepoDetails(Customremotemain customremotemainObj, Integer projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(customremotemainObj,authClient.createAuthHeaders());
+        try {
+            log.info("Setting Custom Repo Details for project id {}", projectId);
+            restTemplate.exchange(cxProperties.getUrl().concat(CUSTOM_PROJ_DETAILS), HttpMethod.POST, requestEntity, String.class, projectId);
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Setting Custom Repo Details for project id {}.", projectId);
+        }
+    }
+
+    private Tfsremotemain getTfsRepoDetails(Integer projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(authClient.createAuthHeaders());
+        try {
+            log.info("Getting TFS Details for project id {}", projectId);
+            ResponseEntity<Tfsremotemain> response =restTemplate.exchange(cxProperties.getUrl().concat(TFS_PROJ_DETAILS), HttpMethod.GET, requestEntity, Tfsremotemain.class, projectId);
+            return response.getBody();
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Getting TFS Details for project id {}.", projectId);
+            return null;
+        }
+    }
+
+    private Svnremotemain getSvnRepoDetails(Integer projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(authClient.createAuthHeaders());
+        try {
+            log.info("Getting SVN Repo Details for project id {}", projectId);
+            ResponseEntity<Svnremotemain> response =restTemplate.exchange(cxProperties.getUrl().concat(SVN_PROJ_DETAILS), HttpMethod.GET, requestEntity, Svnremotemain.class, projectId);
+            return response.getBody();
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Getting SVN Repo Details for project id {}.", projectId);
+            return null;
+        }
+    }
+
+    private Sharedremotemain getSharedRepoDetails(Integer projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(authClient.createAuthHeaders());
+        try {
+            log.info("Getting Shared Details for project id {}", projectId);
+            ResponseEntity<Sharedremotemain> response =restTemplate.exchange(cxProperties.getUrl().concat(SHARED_PROJ_DETAILS), HttpMethod.GET, requestEntity, Sharedremotemain.class, projectId);
+            return response.getBody();
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Getting Shared Details for project id {}.", projectId);
+            return null;
+        }
+    }
+
+    private Perforceremotemain getPerforceRepoDetails(Integer projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(authClient.createAuthHeaders());
+        try {
+            log.info("Getting Perforce Details for project id {}", projectId);
+            ResponseEntity<Perforceremotemain> response =restTemplate.exchange(cxProperties.getUrl().concat(PERFORCE_PROJ_DETAILS), HttpMethod.GET, requestEntity, Perforceremotemain.class, projectId);
+            return response.getBody();
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Getting Perforce Details for project id {}.", projectId);
+            return null;
+        }
+    }
+
+    private Customremotemain getCustomRepoDetails(Integer projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(authClient.createAuthHeaders());
+        try {
+            log.info("Getting Custom Details for project id {}", projectId);
+            ResponseEntity<Customremotemain> response =restTemplate.exchange(cxProperties.getUrl().concat(CUSTOM_PROJ_DETAILS), HttpMethod.GET, requestEntity, Customremotemain.class, projectId);
+            return response.getBody();
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Getting Custom Details for project id {}.", projectId);
+            return null;
+        }
+    }
+
+    private void setGitRepoDetails(Gitremotemain gitremotemainObj,int projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(gitremotemainObj,authClient.createAuthHeaders());
+        try {
+            log.info("Setting Git Repo Details for project id {}", projectId);
+            restTemplate.exchange(cxProperties.getUrl().concat(GIT_PROJ_DETAILS), HttpMethod.POST, requestEntity, String.class, projectId);
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Setting Git Repo Details for project id {}.", projectId);
+        }
+    }
+
+    private Gitremotemain getGitRepoDetails(Integer projectId) {
+        HttpEntity requestEntity = new HttpEntity<>(authClient.createAuthHeaders());
+        try {
+            log.info("Getting Git Repo Details for project id {}", projectId);
+            ResponseEntity<Gitremotemain> response =restTemplate.exchange(cxProperties.getUrl().concat(GIT_PROJ_DETAILS), HttpMethod.GET, requestEntity, Gitremotemain.class, projectId);
+            return response.getBody();
+        } catch (HttpStatusCodeException e) {
+            log.debug(ExceptionUtils.getStackTrace(e));
+            log.debug("Error occurred while Getting Git Repo Details for project id {}.", projectId);
+            return null;
+        }
+    }
 
 
     private void prepareSources(CxScanParams params, Integer projectId) throws CheckmarxException {


### PR DESCRIPTION
See https://github.com/checkmarx-ltd/cx-flow/issues/1151

Describe the problem

The current workflow of submitting scans is currently:

Create a scan with a POST to /sast/scans

Attach a source zip with a POST to /projects/{id}/sourceCode/attachments

The issue is that this overwrites the project source pulling settings. If a user had configured the project for Git as the source location so they can invoke a scan from the UI, this workflow replaces the source location with "zip" and it can no longer be invoked from the UI. If the scan was a scheduled scan, it can no longer execute on schedule since the source zip doesn't exist.

Proposed solution
Use the /sast/scanWithSettings API to invoke scans. The overrideProjectSetting parameter defaults to false so that it does not change the parameters of the source location.

CxFlow should default overrideProjectSetting to true for all scans so that it functions as it currently does. A configurable option to disable the scan settings overwrite should be available to enable the workflow that does not overwrite the source location settings.

Additional Information
Some (if not all) of our other plugins have changed to use this API rather than the original API workflow. I have not verified, but I believe the other plugin implementations don't overwrite the source location settings by default. This likely should be different for CxFlow since many CxFlow installations prefer to disable the ability for project settings to change.

PM Comment:

replace the API between /sast/scans to /scanwithsettings that contains ovrrideprojectsettings

close the GitHub issue when this Story will be closed.