### PR TITLE
CXFLW-967 Custom Map Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.5.66</version>
+	<version>0.5.69</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 	<properties>

--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -63,6 +63,9 @@ public class CxProperties extends CxPropertiesBase{
 
     private Map<String, String> customStateMap;
 
+    @Getter @Setter
+    private Map<String, String> customStateFalsePositiveMap;
+
     private Map<String, String> sshKeyList;
 
     private Boolean cxBranch = false;
@@ -300,6 +303,14 @@ public class CxProperties extends CxPropertiesBase{
 	    stateFullName = customStateMap.get(key);
 	}
 	return stateFullName;
+    }
+
+    public String checkCustomFalsePositive(String key){
+        try {
+            return customStateFalsePositiveMap.get(key);
+        }catch (Exception e){
+            return null;
+        }
     }
 
     public Boolean getGroupBySeverity() {

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -981,6 +981,10 @@ public class CxService implements CxClient {
         if (!resultType.getFalsePositive().equalsIgnoreCase("FALSE")) {
             falsePositive = true;
         }
+        if (cxProperties.checkCustomFalsePositive(resultType.getState())!=null) {
+            log.info("CusumState issue found which is false positive.");
+            falsePositive = true;
+        }
         /*Map issue details*/
         xIssueBuilder.cwe(result.getCweId());
         xIssueBuilder.language(result.getLanguage());


### PR DESCRIPTION
[Map custom result states to false-positives · Issue #1114 · checkmarx-ltd/cx-flow](https://github.com/checkmarx-ltd/cx-flow/issues/1114) 

 

 

Describe the problem
When defining the custom states as it was implemented in [#523](https://github.com/checkmarx-ltd/cx-flow/issues/523), it's not possible to ensure CxFlow sees them as false-positive or true-positive (but since by default custom states represent true-positive, the main issue is with maping custom states to false-positives).

Proposed solution
Enhance the custom state map config by splitting the current custom-state-map in 2 so you have both a true-positive-custom-state-map and false-positive-custom-state-map, where CxFlow succeeds when receiving custom true-positive states and fails on false-positive ones.

Additional Details
The custom-state-map was developed on the sdk here: (see Git hub link)

 

This feature should include the distinction of the custom states on the PR markdown summary's total vulnerability counts, meaning, it should exclude them from the High/Medium/Low/Info counts and from the Violation Summary too.