### PR TITLE
CXFLW-979 Opting Out of Bitbucket comment notifications during PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.6.6</version>
+	<version>0.6.7</version>
 
 
 	<name>cx-spring-boot-sdk</name>

--- a/src/main/java/com/checkmarx/sdk/dto/ast/PackageSeverity.java
+++ b/src/main/java/com/checkmarx/sdk/dto/ast/PackageSeverity.java
@@ -4,5 +4,6 @@ public enum PackageSeverity {
     NONE,
     LOW,
     MEDIUM,
-    HIGH
+    HIGH,
+    CRITICAL
 }

--- a/src/main/java/com/checkmarx/sdk/dto/sast/CxConfig.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sast/CxConfig.java
@@ -21,6 +21,10 @@ public class CxConfig implements Serializable {
     private Double version;
     @JsonProperty("active")
     private Boolean active = true;
+
+    @JsonProperty("scanSubmittedComment")
+    private Boolean scanSubmittedComment = true;
+
     @JsonProperty("host")
     private String host;
     @JsonProperty("credential")
@@ -77,6 +81,16 @@ public class CxConfig implements Serializable {
     @JsonProperty("active")
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    @JsonProperty("scanSubmittedComment")
+    public Boolean getScanSubmittedComment() {
+        return scanSubmittedComment;
+    }
+
+    @JsonProperty("scanSubmittedComment")
+    public void setScanSubmittedComment(Boolean scanSubmittedComment) {
+        this.scanSubmittedComment = scanSubmittedComment;
     }
 
     @JsonProperty("cxHost")

--- a/src/main/java/com/checkmarx/sdk/dto/sca/report/PackageSeverity.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/report/PackageSeverity.java
@@ -8,5 +8,6 @@ public enum PackageSeverity {
 
     LOW,
     MEDIUM,
-    HIGH
+    HIGH,
+    CRITICAL
 }

--- a/src/main/java/com/checkmarx/sdk/dto/scansummary/Severity.java
+++ b/src/main/java/com/checkmarx/sdk/dto/scansummary/Severity.java
@@ -3,5 +3,6 @@ package com.checkmarx.sdk.dto.scansummary;
 public enum Severity {
     LOW,
     MEDIUM,
-    HIGH
+    HIGH,
+    CRITICAL
 }


### PR DESCRIPTION
Customer is requesting a feature to be able to change the .cxflow config file to allow opting in or out when seeing the CxFlow Bitbucket comments during the PR process. The customer is aware that there is a global setting and want to know if that can be optional in the configuration file for who does and does not want to see the comments.