### PR TITLE
CXFLW-979 Opting Out of Bitbucket comment notifications during

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.6.6</version>
+	<version>0.6.7</version>
 
 
 	<name>cx-spring-boot-sdk</name>

--- a/src/main/java/com/checkmarx/sdk/dto/ast/PackageSeverity.java
+++ b/src/main/java/com/checkmarx/sdk/dto/ast/PackageSeverity.java
@@ -4,5 +4,6 @@ public enum PackageSeverity {
     NONE,
     LOW,
     MEDIUM,
-    HIGH
+    HIGH,
+    CRITICAL
 }

--- a/src/main/java/com/checkmarx/sdk/dto/cx/CxScanSummary.java
+++ b/src/main/java/com/checkmarx/sdk/dto/cx/CxScanSummary.java
@@ -2,6 +2,8 @@ package com.checkmarx.sdk.dto.cx;
 
 import java.time.LocalDateTime;
 import java.util.Map;
+
+import com.checkmarx.sdk.config.CxProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -16,6 +18,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 })
 public class CxScanSummary {
 
+    @JsonProperty("criticalSeverity")
+    private Integer criticalSeverity;
     @JsonProperty("highSeverity")
     private Integer highSeverity;
     @JsonProperty("mediumSeverity")
@@ -30,6 +34,7 @@ public class CxScanSummary {
     public CxScanSummary() { }
 
     public CxScanSummary(Map<String, Integer> summary) {
+        criticalSeverity = summary.getOrDefault("Critical", 0);
         highSeverity = summary.getOrDefault("High", 0);
         mediumSeverity = summary.getOrDefault("Medium", 0);
         lowSeverity = summary.getOrDefault("Low", 0);
@@ -37,6 +42,15 @@ public class CxScanSummary {
         LocalDateTime now = LocalDateTime.now();
         statisticsCalculationDate = now.toString();
     }
+
+    public Integer getCriticalSeverity() {
+        return criticalSeverity;
+    }
+
+    public void setCriticalSeverity(Integer criticalSeverity) {
+        this.criticalSeverity = criticalSeverity;
+    }
+
     public Integer getHighSeverity() {
         return highSeverity;
     }
@@ -79,6 +93,6 @@ public class CxScanSummary {
 
     @Override
     public String toString() {
-        return String.format("high: %s, medium: %s, low: %s, info: %s", highSeverity, mediumSeverity, lowSeverity, infoSeverity);
+            return String.format("critical:%s, high: %s, medium: %s, low: %s, info: %s",criticalSeverity, highSeverity, mediumSeverity, lowSeverity, infoSeverity);
     }
 }

--- a/src/main/java/com/checkmarx/sdk/dto/cxgo/SASTScanResult.java
+++ b/src/main/java/com/checkmarx/sdk/dto/cxgo/SASTScanResult.java
@@ -249,6 +249,7 @@ public class SASTScanResult {
     }
 
     public enum Severity {
+        CRITICAL("CRITICAL"),
         HIGH("HIGH"),
         MEDIUM("MEDIUM"),
         LOW("LOW"),

--- a/src/main/java/com/checkmarx/sdk/dto/sast/CxConfig.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sast/CxConfig.java
@@ -21,6 +21,10 @@ public class CxConfig implements Serializable {
     private Double version;
     @JsonProperty("active")
     private Boolean active = true;
+
+    @JsonProperty("scanSubmittedComment")
+    private Boolean scanSubmittedComment = true;
+
     @JsonProperty("host")
     private String host;
     @JsonProperty("credential")
@@ -77,6 +81,16 @@ public class CxConfig implements Serializable {
     @JsonProperty("active")
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    @JsonProperty("scanSubmittedComment")
+    public Boolean getScanSubmittedComment() {
+        return scanSubmittedComment;
+    }
+
+    @JsonProperty("scanSubmittedComment")
+    public void setScanSubmittedComment(Boolean scanSubmittedComment) {
+        this.scanSubmittedComment = scanSubmittedComment;
     }
 
     @JsonProperty("cxHost")

--- a/src/main/java/com/checkmarx/sdk/dto/sca/SCAResults.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/SCAResults.java
@@ -33,7 +33,7 @@ public class SCAResults extends ResultsBase implements Serializable {
         int sum;
         if (this.packages != null) {
             for (Package pckg : this.packages) {
-                sum = pckg.getHighVulnerabilityCount() + pckg.getMediumVulnerabilityCount() + pckg.getLowVulnerabilityCount();
+                sum = pckg.getCriticalVulnerabilityCount()+pckg.getHighVulnerabilityCount() + pckg.getMediumVulnerabilityCount() + pckg.getLowVulnerabilityCount();
                 if (sum == 0) {
                     this.nonVulnerableLibraries++;
                 } else if (sum > 0 && pckg.isOutdated()) {

--- a/src/main/java/com/checkmarx/sdk/dto/sca/report/Package.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/report/Package.java
@@ -23,7 +23,7 @@ public class Package implements Serializable {
      * The current values are [Filename, Sha1]. Not considered an enum in SCA API.
      */
     private String matchType;
-
+    private int criticalVulnerabilityCount;
     private int highVulnerabilityCount;
     private int mediumVulnerabilityCount;
     private int lowVulnerabilityCount;

--- a/src/main/java/com/checkmarx/sdk/dto/sca/report/PackageSeverity.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/report/PackageSeverity.java
@@ -8,5 +8,6 @@ public enum PackageSeverity {
 
     LOW,
     MEDIUM,
-    HIGH
+    HIGH,
+    CRITICAL
 }

--- a/src/main/java/com/checkmarx/sdk/dto/sca/report/ScaSummaryBaseFormat.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/report/ScaSummaryBaseFormat.java
@@ -9,6 +9,7 @@ public class ScaSummaryBaseFormat implements Serializable {
     private String createdOn;
     private double riskScore;
     private int totalOutdatedPackages;
+    private int criticalVulnerabilityCount = 0;
     private int highVulnerabilityCount = 0;
     private int mediumVulnerabilityCount = 0;
     private int lowVulnerabilityCount = 0;
@@ -16,19 +17,20 @@ public class ScaSummaryBaseFormat implements Serializable {
     public ScaSummaryBaseFormat() {
     }
 
-    public ScaSummaryBaseFormat(int totalPackages, int directPackages, String createdOn, double riskScore, int totalOutdatedPackages, int highVulnerabilityCount, int mediumVulnerabilityCount, int lowVulnerabilityCount) {
+    public ScaSummaryBaseFormat(int totalPackages, int directPackages, String createdOn, double riskScore, int totalOutdatedPackages, int criticalVulnerabilityCount,int highVulnerabilityCount, int mediumVulnerabilityCount, int lowVulnerabilityCount) {
         this.totalPackages = totalPackages;
         this.directPackages = directPackages;
         this.createdOn = createdOn;
         this.riskScore = riskScore;
         this.totalOutdatedPackages = totalOutdatedPackages;
+        this.criticalVulnerabilityCount = criticalVulnerabilityCount;
         this.highVulnerabilityCount = highVulnerabilityCount;
         this.mediumVulnerabilityCount = mediumVulnerabilityCount;
         this.lowVulnerabilityCount = lowVulnerabilityCount;
     }
 
     public int getTotalOkLibraries() {
-        int totalOk = (totalPackages - (highVulnerabilityCount + mediumVulnerabilityCount + lowVulnerabilityCount));
+        int totalOk = (totalPackages - (criticalVulnerabilityCount+highVulnerabilityCount + mediumVulnerabilityCount + lowVulnerabilityCount));
         totalOk = Math.max(totalOk, 0);
         return totalOk;
     }
@@ -95,5 +97,12 @@ public class ScaSummaryBaseFormat implements Serializable {
 
     public void setLowVulnerabilityCount(int lowVulnerabilityCount) {
         this.lowVulnerabilityCount = lowVulnerabilityCount;
+    }
+    public int getCriticalVulnerabilityCount() {
+        return criticalVulnerabilityCount;
+    }
+
+    public void setCriticalVulnerabilityCount(int criticalVulnerabilityCount) {
+        this.criticalVulnerabilityCount = criticalVulnerabilityCount;
     }
 }

--- a/src/main/java/com/checkmarx/sdk/dto/sca/xml/PackageType.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/xml/PackageType.java
@@ -61,6 +61,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
     "version",
     "licenses",
     "matchType",
+    "CriticalVulnerabilityCount",
     "highVulnerabilityCount",
     "mediumVulnerabilityCount",
     "lowVulnerabilityCount",
@@ -93,6 +94,8 @@ public class PackageType {
     protected LicensesType licenses;
     @XmlElement(name = "MatchType", required = true)
     protected String matchType;
+    @XmlElement(name = "CriticalVulnerabilityCount")
+    protected byte criticalVulnerabilityCount;
     @XmlElement(name = "HighVulnerabilityCount")
     protected byte highVulnerabilityCount;
     @XmlElement(name = "MediumVulnerabilityCount")
@@ -251,6 +254,17 @@ public class PackageType {
      */
     public void setMatchType(String value) {
         this.matchType = value;
+    }
+    /**
+     * Gets the value of the criticalVulnerabilityCount property.
+     *
+     */
+    public byte getCriticalVulnerabilityCount() {
+        return criticalVulnerabilityCount;
+    }
+
+    public void setCriticalVulnerabilityCount(byte criticalVulnerabilityCount) {
+        this.criticalVulnerabilityCount = criticalVulnerabilityCount;
     }
 
     /**

--- a/src/main/java/com/checkmarx/sdk/dto/sca/xml/RiskReportSummaryType.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/xml/RiskReportSummaryType.java
@@ -26,6 +26,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
  *         &lt;element name="ProjectId" type="{http://www.w3.org/2001/XMLSchema}string"/>
  *         &lt;element name="ProjectName" type="{http://www.w3.org/2001/XMLSchema}string"/>
  *         &lt;element name="ProjectCreatedOn" type="{http://www.w3.org/2001/XMLSchema}dateTime"/>
+ *         &lt;element name="CriticalVulnerabilityCount" type="{http://www.w3.org/2001/XMLSchema}byte"/>
  *         &lt;element name="HighVulnerabilityCount" type="{http://www.w3.org/2001/XMLSchema}byte"/>
  *         &lt;element name="MediumVulnerabilityCount" type="{http://www.w3.org/2001/XMLSchema}byte"/>
  *         &lt;element name="LowVulnerabilityCount" type="{http://www.w3.org/2001/XMLSchema}byte"/>
@@ -61,6 +62,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
     "projectId",
     "projectName",
     "projectCreatedOn",
+    "CriticalVulnerabilityCount",
     "highVulnerabilityCount",
     "mediumVulnerabilityCount",
     "lowVulnerabilityCount",
@@ -70,7 +72,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
     "riskScore",
     "totalOutdatedPackages",
     "vulnerablePackages",
-    "totalPackagesWithLegalRisk",
+    "totalPackagesWithLegalRisk", "criticalVulnerablePackages",
     "highVulnerablePackages",
     "mediumVulnerablePackages",
     "lowVulnerablePackages",
@@ -94,6 +96,8 @@ public class RiskReportSummaryType {
     @XmlElement(name = "ProjectCreatedOn", required = true)
     @XmlSchemaType(name = "dateTime")
     protected XMLGregorianCalendar projectCreatedOn;
+    @XmlElement(name = "CriticalVulnerabilityCount")
+    protected byte criticalVulnerabilityCount;
     @XmlElement(name = "HighVulnerabilityCount")
     protected byte highVulnerabilityCount;
     @XmlElement(name = "MediumVulnerabilityCount")
@@ -408,6 +412,14 @@ public class RiskReportSummaryType {
      */
     public byte getHighVulnerablePackages() {
         return highVulnerablePackages;
+    }
+
+    public byte getCriticalVulnerabilityCount() {
+        return criticalVulnerabilityCount;
+    }
+
+    public void setCriticalVulnerabilityCount(byte criticalVulnerabilityCount) {
+        this.criticalVulnerabilityCount = criticalVulnerabilityCount;
     }
 
     /**

--- a/src/main/java/com/checkmarx/sdk/dto/scansummary/Severity.java
+++ b/src/main/java/com/checkmarx/sdk/dto/scansummary/Severity.java
@@ -3,5 +3,6 @@ package com.checkmarx.sdk.dto.scansummary;
 public enum Severity {
     LOW,
     MEDIUM,
-    HIGH
+    HIGH,
+    CRITICAL
 }

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -4,7 +4,6 @@ import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.config.CxPropertiesBase;
 import com.checkmarx.sdk.dto.cx.preandpostaction.CustomTaskByName;
-import com.checkmarx.sdk.dto.cx.preandpostaction.ListCustomeObj;
 import com.checkmarx.sdk.dto.cx.preandpostaction.ScanSettings;
 import com.checkmarx.sdk.dto.cx.projectdetails.ProjectFieldDetails;
 import com.checkmarx.sdk.dto.sast.Filter;
@@ -55,9 +54,7 @@ import java.io.*;
 import java.net.*;
 import java.nio.file.Files;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -3164,14 +3161,22 @@ public class CxService implements CxClient {
         }
     }
 
-    public void getAndUpdateSASTVersion(){
-        HttpEntity requestEntity = new HttpEntity<>(authClient.createAuthHeaders());
-        ResponseEntity<String> response = restTemplate.exchange(cxProperties.getUrl().concat(VERSION), HttpMethod.GET, requestEntity, String.class);
-        JSONObject obj = new JSONObject(Objects.requireNonNull(response.getBody()));
-        String versionName = obj.getString("version");
-        Double version=Double.parseDouble(versionName.split("\\.",3)[0]+"."+ versionName.split("\\.",3)[1]);
-        log.info("using SAST version :{}",version);
-        cxProperties.setVersion(version);
+    public void getAndUpdateSASTVersion() {
+        try{
+            HttpEntity<Object> requestEntity = new HttpEntity<>(authClient.createAuthHeaders());
+            ResponseEntity<String> response = restTemplate.exchange(cxProperties.getUrl().concat(VERSION), HttpMethod.GET, requestEntity, String.class);
+            JSONObject obj = new JSONObject(Objects.requireNonNull(response.getBody()));
+            String versionName = obj.getString("version");
+            Double version=Double.parseDouble(versionName.split("\\.",3)[0]+"."+ versionName.split("\\.",3)[1]);
+            log.info("using SAST version :{}",version);
+            cxProperties.setVersion(version);
+        } catch (HttpStatusCodeException e) {
+            log.error("Error occurred while SAST version, http error {}", e.getStatusCode());
+            log.error(ExceptionUtils.getStackTrace(e));
+        } catch (JSONException e) {
+            log.error("Error occurred while processing JSON");
+            log.error(ExceptionUtils.getStackTrace(e));
+        }
     }
 
     private void validateScanParams(CxScanParams params) throws CheckmarxException {

--- a/src/main/java/com/checkmarx/sdk/utils/CxRepoFileHelper.java
+++ b/src/main/java/com/checkmarx/sdk/utils/CxRepoFileHelper.java
@@ -13,6 +13,7 @@ import groovy.util.ScriptException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -23,12 +24,12 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.DosFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.*;
+import java.util.regex.Pattern;
 
 @Slf4j
 public class CxRepoFileHelper {

--- a/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
+++ b/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
@@ -1131,6 +1131,7 @@ public class ScaClientHelper extends ScanClientHelper implements IScanClientHelp
             packge.setName(packageTypeList.get(count).getName());
             packge.setVersion(packageTypeList.get(count).getVersion());
             packge.setMatchType(packageTypeList.get(count).getMatchType());
+            packge.setCriticalVulnerabilityCount(packageTypeList.get(count).getCriticalVulnerabilityCount());
             packge.setHighVulnerabilityCount(packageTypeList.get(count).getHighVulnerabilityCount());
             packge.setLowVulnerabilityCount(packageTypeList.get(count).getLowVulnerabilityCount());
             packge.setMediumVulnerabilityCount(packageTypeList.get(count).getMediumVulnerabilityCount());
@@ -1253,6 +1254,7 @@ public class ScaClientHelper extends ScanClientHelper implements IScanClientHelp
         scaSummaryBaseFormat.setTotalPackages(riskReportSummaryType.getTotalPackages());
         scaSummaryBaseFormat.setTotalOutdatedPackages(riskReportSummaryType.getTotalOutdatedPackages());
         scaSummaryBaseFormat.setCreatedOn(riskReportSummaryType.getCreatedOn().toString());
+        scaSummaryBaseFormat.setCriticalVulnerabilityCount(riskReportSummaryType.getCriticalVulnerabilityCount());
         scaSummaryBaseFormat.setHighVulnerabilityCount(riskReportSummaryType.getHighVulnerabilityCount());
         scaSummaryBaseFormat.setLowVulnerabilityCount(riskReportSummaryType.getLowVulnerabilityCount());
         scaSummaryBaseFormat.setMediumVulnerabilityCount(riskReportSummaryType.getMediumVulnerabilityCount());
@@ -1562,6 +1564,7 @@ public class ScaClientHelper extends ScanClientHelper implements IScanClientHelp
 
     protected Map<Filter.Severity, Integer> getFindingCountMap(ScaSummaryBaseFormat summary) {
         EnumMap<Filter.Severity, Integer> result = new EnumMap<>(Filter.Severity.class);
+        result.put(Filter.Severity.CRITICAL,summary.getCriticalVulnerabilityCount());
         result.put(Filter.Severity.HIGH, summary.getHighVulnerabilityCount());
         result.put(Filter.Severity.MEDIUM, summary.getMediumVulnerabilityCount());
         result.put(Filter.Severity.LOW, summary.getLowVulnerabilityCount());
@@ -1725,6 +1728,7 @@ public class ScaClientHelper extends ScanClientHelper implements IScanClientHelp
             log.info("----CxSCA risk report summary----");
             log.info("Created on: {}", summary.getCreatedOn());
             log.info("Direct packages: {}", summary.getDirectPackages());
+            log.info("Critical vulnerabilities: {}",summary.getCriticalVulnerabilityCount());
             log.info("High vulnerabilities: {}", summary.getHighVulnerabilityCount());
             log.info("Medium vulnerabilities: {}", summary.getMediumVulnerabilityCount());
             log.info("Low vulnerabilities: {}", summary.getLowVulnerabilityCount());


### PR DESCRIPTION
Customer is requesting a feature to be able to change the .cxflow config file to allow opting in or out when seeing the CxFlow Bitbucket comments during the PR process. The customer is aware that there is a global setting and want to know if that can be optional in the configuration file for who does and does not want to see the comments.