### PR TITLE
Incremental Scan Issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.6.7</version>
+	<version>0.6.8</version>
 
 
 	<name>cx-spring-boot-sdk</name>

--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -100,6 +100,9 @@ public class CxProperties extends CxPropertiesBase{
     @Getter @Setter
     private Boolean overrideProjectSetting = true;
 
+    @Getter @Setter
+    private Boolean considerScanningStatus = false;
+
 
     /**
      * Maps finding state ID (as returned in CxSAST report) to state name (as specified in filter configuration).

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -284,13 +284,20 @@ public class CxService implements CxClient {
 
         log.info("Finding last Scan Id for project Id {}", projectId);
         try {
-            UriComponents uriComponents = UriComponentsBuilder
+
+            UriComponents uriComponents = cxProperties.getConsiderScanningStatus() ? (UriComponentsBuilder
                     .fromHttpUrl(cxProperties.getUrl())
                     .path(SCAN)
                     .queryParam("projectId", projectId.toString())
-                    .queryParam("scanStatus", SCAN_STATUS_FINISHED.toString())
-                    .queryParam("last",cxProperties.getIncrementalNumScans().toString())
-                    .build();
+                    .queryParam("last", cxProperties.getIncrementalNumScans().toString())
+                    .build()) : (UriComponentsBuilder
+                    .fromHttpUrl(cxProperties.getUrl())
+                    .path(SCAN)
+                    .queryParam("projectId", projectId.toString())
+                    .queryParam("scanStatus",
+                            SCAN_STATUS_FINISHED.toString())
+                    .queryParam("last", cxProperties.getIncrementalNumScans().toString())
+                    .build());
 
             ResponseEntity<String> response = restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, requestEntity, String.class);
 
@@ -304,7 +311,8 @@ public class CxService implements CxClient {
                     //example: "finishedOn": "2018-06-18T01:09:12.707", Grab only first 19 digits due to inconsistency of checkmarx results
                     LocalDateTime d;
                     try {
-                        String finishedOn = dateAndTime.getString("finishedOn");
+                        String finishedOn =
+                                cxProperties.getConsiderScanningStatus() ? dateAndTime.getString("startedOn") : dateAndTime.getString("finishedOn");
                         finishedOn = finishedOn.substring(0, 19);
                         log.debug("finishedOn: {}", finishedOn);
                         d = LocalDateTime.parse(finishedOn, formatter);


### PR DESCRIPTION
Description

The customer is encountering abnormal behavior during concurrent scans in their Static Application Security Testing (SAST) process. This anomaly arises because the Cx-flow tool exclusively checks for successful scans, resulting in full scans for all concurrent requests. Consequently, the tool's inability to efficiently handle concurrent requests leads to redundant and resource-intensive scanning activities. This inefficiency not only prolongs scan times but also increases the likelihood of resource contention and inconsistencies in scan results. To address this issue, it's imperative to enhance the SAST tool's concurrency management capabilities. 

Steps to Reproduce

set full scan after every 5 scan and then perform 5 scans one by one it will be incremental after that perform more than one scans parallelly for and then check in SAST all concurrent request will have full scan ideally only one should have full scan and other requests should be incremental
Actual Result

set full scan after every 5 scan and then perform 5 scans one by one it will be incremental after that perform more than one scans parallelly for and then check in SAST all concurrent request will have full scan ideally only one should have full scan and other requests should be incremental
Expected Result

set full scan after every 5 scan and then perform 5 scans one by one it will be incremental after that perform more than one scans parallelly for and then check in SAST all concurrent request will have full scan ideally only one should have full scan and other requests should be incremental
Possible solution

https://sast94.cxquality.com/cxrestapi/sast/scans?projectId=885&scanStatus=7&last=5
instead of scan status 7 we should consider queued scans as well