### PR TITLE
CXFLW-1235 Adding code for self-sign certificate SSL bypass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.6.8</version>
+	<version>0.6.9</version>
 
 
 	<name>cx-spring-boot-sdk</name>
@@ -152,6 +152,10 @@
 			<groupId>com.github.ulisesbocchio</groupId>
 			<artifactId>jasypt-spring-boot-starter</artifactId>
 			<version>3.0.5</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -43,7 +43,9 @@ public class CxProperties extends CxPropertiesBase{
     @Setter
     private int queuecapacityarg;
 
-
+    @Getter
+    @Setter
+    private boolean trustcerts = false;
     
     private Integer httpConnectionTimeout = 30000;
     private Integer httpReadTimeout = 120000;


### PR DESCRIPTION
Adding a self-sign certificate SSL bypass in CXFlow requires careful consideration, as this process involves security implications. CXFlow is a framework designed to simplify the orchestration of various CI/CD tools and processes, and ensuring secure communication within the system is crucial. However, there are scenarios where you might need to bypass SSL verification, such as during testing or when dealing with self-signed certificates in a development environment. This guide will walk you through the necessary steps to add a self-sign certificate SSL bypass in CXFlow.

Understanding SSL Verification
SSL (Secure Socket Layer) is a standard security protocol for establishing encrypted links between a web server and a browser in an online communication. It ensures that all data passed between the web server and browsers remain private and integral. When using SSL, servers present certificates to clients (browsers or other services) to establish their identity. Self-signed certificates are certificates that are not signed by a recognized certificate authority (CA). They are typically used in development environments or for internal purposes.

Why Bypass SSL Verification?
Bypassing SSL verification can be necessary in certain scenarios, such as:

Development and Testing: When you are in a controlled environment and the overhead of obtaining a CA-signed certificate is unnecessary.
Internal Systems: For internal systems where the risk of man-in-the-middle attacks is controlled and the environment is trusted.
Implementing SSL Bypass in CXFlow
To implement SSL bypass for self-signed certificates in CXFlow, you need to configure the HTTP client used by CXFlow to ignore SSL certificate validation errors. This can be done by customizing the underlying HTTP client to trust all certificates.

Steps to Add SSL Bypass:
Identify the HTTP Client:
CXFlow likely uses an HTTP client library (such as Apache HttpClient, OkHttp, or Java’s HttpsURLConnection). Identify the HTTP client being used in the CXFlow project.

Custom Trust Manager:
Create a custom TrustManager that trusts all certificates. This involves creating an implementation of javax.net.ssl.X509TrustManager that does not validate certificate chains.

java
Copy code
import javax.net.ssl.X509TrustManager;
import java.security.cert.X509Certificate;

public class TrustAllCertificates implements X509TrustManager {
    public X509Certificate[] getAcceptedIssuers() {
        return null;
    }

    public void checkClientTrusted(X509Certificate[] certs, String authType) {
        // Trust all client certificates
    }

    public void checkServerTrusted(X509Certificate[] certs, String authType) {
        // Trust all server certificates
    }
}
Custom SSL Context:
Create an SSLContext that uses this TrustManager.

java
Copy code
import javax.net.ssl.SSLContext;
import javax.net.ssl.TrustManager;

public class SSLUtils {
    public static SSLContext createTrustAllSslContext() throws Exception {
        SSLContext sslContext = SSLContext.getInstance("TLS");
        TrustManager[] trustAllCerts = new TrustManager[]{new TrustAllCertificates()};
        sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
        return sslContext;
    }
}
Configure HTTP Client:
Configure the HTTP client to use this SSLContext. For example, if using Apache HttpClient:

java
Copy code
import org.apache.http.impl.client.CloseableHttpClient;
import org.apache.http.impl.client.HttpClients;
import org.apache.http.conn.ssl.NoopHostnameVerifier;
import org.apache.http.ssl.SSLContextBuilder;

SSLContext sslContext = SSLUtils.createTrustAllSslContext();

CloseableHttpClient httpClient = HttpClients.custom()
        .setSSLContext(sslContext)
        .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
        .build();
Integrate with CXFlow:
Ensure that CXFlow uses this configured HTTP client for making HTTP requests. This might involve updating configurations or modifying the part of the code where the HTTP client is instantiated.

Security Implications
Bypassing SSL verification can expose your system to security risks, such as man-in-the-middle attacks. This approach should only be used in trusted and controlled environments, such as internal networks or during development and testing phases. For production environments, always use certificates signed by a recognized CA and ensure proper SSL verification to maintain security integrity.

Conclusion
Adding a self-sign certificate SSL bypass in CXFlow involves customizing the HTTP client to trust all certificates. While this approach can be useful in specific scenarios, it should be used with caution due to potential security risks. Always ensure that the environments where SSL bypass is enabled are secure and controlled, and revert to standard SSL verification practices in production environments.