### PR TITLE
Added code for support of custom key store

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.6.9</version>
+	<version>0.6.10</version>
 
 
 	<name>cx-spring-boot-sdk</name>

--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -46,6 +46,13 @@ public class CxProperties extends CxPropertiesBase{
     @Getter
     @Setter
     private boolean trustcerts = false;
+
+    @Getter
+    @Setter
+    private String truststorepath;
+    @Getter
+    @Setter
+    private String truststorepassword;
     
     private Integer httpConnectionTimeout = 30000;
     private Integer httpReadTimeout = 120000;
@@ -76,6 +83,9 @@ public class CxProperties extends CxPropertiesBase{
     private Map<String, String> sshKeyList;
 
     private Boolean cxBranch = false;
+
+    @Getter @Setter
+    private Boolean customkeystore = false;
 
     /*
      * If set to true, group results by vulnerability, filename and


### PR DESCRIPTION
To allow CXFlow to accept custom enterprise certificates without altering the default cacert, you can configure it to trust additional certificates by adding them to a custom trust store.