### PR TITLE
CXFLW-1437 Added code to download SCA critical issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.6.15</version>
+	<version>0.6.16</version>
 
 
 	<name>cx-spring-boot-sdk</name>

--- a/src/main/java/com/checkmarx/sdk/dto/sca/ScaPDFExport.java
+++ b/src/main/java/com/checkmarx/sdk/dto/sca/ScaPDFExport.java
@@ -1,0 +1,13 @@
+package com.checkmarx.sdk.dto.sca;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ScaPDFExport {
+    private String scanId;
+    private String fileFormat;
+}


### PR DESCRIPTION
Description

When dealing with the issue where the CxFlow SCA PDF Download does not include details of a critical severity issue via API, it's important to understand the context and what might be causing the problem. Below is an elaboration on this issue:

Context and Background
CxFlow (Checkmarx Flow) is a tool used for automating security scans in CI/CD pipelines, often integrating with various application security testing tools like SCA (Software Composition Analysis). The CxFlow SCA feature helps identify vulnerabilities in third-party libraries and open-source components used within a codebase.

Problem Statement
The issue arises when users attempt to generate a PDF report through the CxFlow API after a scan, expecting it to include details about vulnerabilities, particularly those with critical severity. However, the generated PDF is missing this critical information.

Possible Causes
API Configuration Issues:

The API request might not be configured correctly to include all severity levels in the report. Some parameters or filters in the API request might exclude critical severity issues.

SCA Data Retrieval Issues:

There could be a problem with how CxFlow retrieves or processes data from the SCA tool. If the SCA scan does not correctly identify or flag certain critical issues, these will not be included in the PDF.

PDF Generation Logic:

The logic used to generate the PDF might have a bug or limitation where it inadvertently omits critical severity issues. This could be due to hardcoded thresholds or errors in the data handling process.

Incomplete Scan Data:

If the scan itself did not complete correctly or missed analyzing certain components, the PDF would naturally lack complete details, including critical severity issues.

Versioning or Update Issues:

If there have been recent updates or changes in either the CxFlow or the SCA tool, incompatibilities or unaddressed bugs could lead to missing information in the report.

Steps to Investigate and Resolve
Check API Request Parameters:

Review the API request being sent to ensure that it includes parameters to retrieve all severity levels, especially critical ones.

Review SCA Scan Results:

Before generating the PDF, ensure that the scan results, as retrieved from the SCA tool, actually contain critical severity issues. Cross-check this against the raw scan data.

Inspect PDF Generation Code:

If you have access to the CxFlow code or can report the issue to the developers, investigate the code responsible for PDF generation to see if it is correctly processing all scan data.

Re-run Scans:

Consider re-running the scan to ensure that the results are comprehensive and that no components or vulnerabilities were missed.

Check for Updates or Patches:

Ensure that both CxFlow and the SCA tool are up to date with the latest patches and updates, which might address known issues with PDF report generation.

Contact Support:

If the issue persists, contacting Checkmarx support might be necessary to get further assistance. Providing them with logs and the specific API request could help them diagnose the problem.

Conclusion
This issue, where the CxFlow SCA PDF does not contain details of critical severity issues, is likely due to a combination of factors related to API configuration, data retrieval, or report generation logic. Systematic investigation and validation of each stage from scan to report generation are key to resolving the issue.

Steps to Reproduce

Run cxflow by enabling PDF as bug tracker .
Actual Result

None
Expected Result

Generated PDF should have Critical severity
Possible solution

Insted of this AP
/risk-management/risk-reports/{scan_id}/export?format={file_type}

Use below API

POST:
https://api-sca.checkmarx.net/export/requests

GET:
https://api-sca.checkmarx.net/export/requests/ff3638ac-99e3-42c5-b129-90e6c64a3e32/download