### PR TITLE
CXFLW-1479 added code for inprogress scan if scan timeout occurs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.6.16</version>
+	<version>0.6.17</version>
 
 
 	<name>cx-spring-boot-sdk</name>

--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -36,6 +36,10 @@ public class CxProperties extends CxPropertiesBase{
 
     @Getter
     @Setter
+    private Boolean cancelInpregressScan = false;
+
+    @Getter
+    @Setter
     @Builder.Default
     private Boolean isBranchedIncremental = false;
 

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -2765,10 +2765,9 @@ public class CxService implements CxClient {
      *
      * @param scanId
      * @return
-     * @throws CheckmarxException
      */
     @Override
-    public void cancelScan(Integer scanId) throws CheckmarxException {
+    public void cancelScan(Integer scanId) {
         log.info("Canceling scan with id {}", scanId);
         try {
             JSONObject scanRequest = new JSONObject();
@@ -3280,6 +3279,10 @@ public class CxService implements CxClient {
                     }
                 }
                 if (timer >= (cxProperties.getScanTimeout() * 60000)) {
+                    if(cxProperties.getCancelInpregressScan()){
+                        cancelScan(scanId);
+                    }
+
                     log.error("Scan timeout exceeded.  {} minutes", cxProperties.getScanTimeout());
                     throw new CheckmarxException("Timeout exceeded during scan");
                 }
@@ -3312,4 +3315,10 @@ public class CxService implements CxClient {
         // TODO Auto-generated method stub
 
     }
+
+
+
+
+
+
 }


### PR DESCRIPTION
checkmarx-cxflow-github-action has a option checkmarx.scan-timeout. This basically fails the steps and exits. But this does not cancel the running scan / queued scan causing a build up of queued scan.

This needs to be fixed in the action. I raised a support case since the checkmarx team does not reply to the issues raised on the action's repository.