### PR TITLE
CXFLW-1482 Fix for name creation issue in branching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.6.19</version>
+	<version>0.6.20</version>
 
 
 	<name>cx-spring-boot-sdk</name>

--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -40,6 +40,10 @@ public class CxProperties extends CxPropertiesBase{
 
     @Getter
     @Setter
+    private Boolean isDefaultBranchEmpty = false;
+
+    @Getter
+    @Setter
     @Builder.Default
     private Boolean isBranchedIncremental = false;
 

--- a/src/main/java/com/checkmarx/sdk/service/CxService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxService.java
@@ -2298,7 +2298,11 @@ public class CxService implements CxClient {
 
                             derivedProjectName = params.getProjectName().replace(params.getModifiedProjectName(),defaultBranch);
                         }else{
-                            derivedProjectName = params.getProjectName() + "-" + defaultBranch;
+                            if(cxProperties.getIsDefaultBranchEmpty() && (defaultBranch==null || defaultBranch.isEmpty())){
+                                derivedProjectName = params.getProjectName();
+                            }else{
+                                derivedProjectName = params.getProjectName() + "-" + defaultBranch;
+                            }
                         }
                     }
 
@@ -2307,7 +2311,13 @@ public class CxService implements CxClient {
                     if(baseProjectId.equals(UNKNOWN_INT)){
                         baseProjectId = createProject(teamId, derivedProjectName);
                     }
-                    projectId = branchProject(baseProjectId, params.getProjectName());
+
+                    if(cxProperties.getIsDefaultBranchEmpty() && (defaultBranch==null || defaultBranch.isEmpty()) && (currentBranch!=null || !currentBranch.isEmpty())){
+                        projectId = branchProject(baseProjectId, params.getProjectName()+"-"+currentBranch);
+                    }else{
+                        projectId = branchProject(baseProjectId, params.getProjectName());
+                    }
+
                 } else {
                     projectId = createProject(teamId, params.getProjectName());
                 }


### PR DESCRIPTION
Description

In CXFlow, the branch creation logic adds a trailing hyphen (-) when the default branch is not provided. This leads to branch names such as projectname-, which is incorrect. The branch name should not include the hyphen if the default branch is missing.

Steps to Reproduce



Provide a project name (e.g., projectname).
Provide a current branch name (e.g., main).
Do not provide a default branch.
Actual Result

The branch name should be: projectname-main and projectname-.
Expected Result

The branch name should be: projectname-main and projectname.
Possible solution

Modify the logic to check if the default branch is provided.
If the default branch is present, the branch name should be projectname-currentBranch-defaultBranch.
If the default branch is not provided, the branch name should be projectname-currentBranch, without any trailing hyphen.

String projectName = "projectname";
String currentBranch = "main";
String defaultBranch = ""; // This is empty, no default branch provided

String branchName = projectName + "-" + currentBranch;
if (!defaultBranch.isEmpty()) {
branchName += "-" + defaultBranch;
}

// Result: "projectname-main" without a trailing hyphen if no defaultBranch is provided