### PR TITLE
CXFLW-1519 added code to support token based authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.6.19</version>
+	<version>0.6.20</version>
 
 
 	<name>cx-spring-boot-sdk</name>

--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -40,6 +40,15 @@ public class CxProperties extends CxPropertiesBase{
 
     @Getter
     @Setter
+    private Boolean enableTokenLogin = false;
+
+    @Getter
+    @Setter
+    private String token ;
+
+
+    @Getter
+    @Setter
     @Builder.Default
     private Boolean isBranchedIncremental = false;
 

--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -48,6 +48,9 @@ public class CxProperties extends CxPropertiesBase{
     private String token ;
 
 
+    @Getter
+    @Setter
+    @Builder.Default
     private Boolean isDefaultBranchEmpty = false;
 
 

--- a/src/main/java/com/checkmarx/sdk/service/CxAuthService.java
+++ b/src/main/java/com/checkmarx/sdk/service/CxAuthService.java
@@ -225,7 +225,13 @@ public class CxAuthService implements CxAuthClient{
         //
         /// If shards are enabled then fetch the token from the shard; otherwise, use the local one
         //
-        String authToken = token;
+        String authToken ;
+
+        if(cxProperties.getEnableTokenLogin()){
+        token= cxProperties.getToken();
+        }
+
+        authToken = token;
         if(cxProperties.getEnableShardManager()) {
             ShardSession shard = sessionTracker.getShardSession();
             authToken = shard.getAccessToken();
@@ -234,7 +240,11 @@ public class CxAuthService implements CxAuthClient{
         /// Get a new access token if missing or has expired.
         //
         if (authToken == null || isTokenExpired()) {
-            getAuthToken();
+            if(cxProperties.getEnableTokenLogin()){
+                token= cxProperties.getToken();
+            }else{
+                getAuthToken();
+            }
             authToken = token;
         }
         //


### PR DESCRIPTION
Currently, CxFlow only supports using the CxSAST username and password for authentication. Supporting token-based authentication (as the CLI plugin does) would mean that the CxSAST password does not need to be used (and thus potentially exposed).