### PR TITLE
 Fix for Exploitable path for ScaResolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ltd</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.6.27</version>
+	<version>0.6.28</version>
 
 
 	<name>cx-spring-boot-sdk</name>

--- a/src/main/java/com/checkmarx/sdk/utils/scaResolver/ScaResolverUtils.java
+++ b/src/main/java/com/checkmarx/sdk/utils/scaResolver/ScaResolverUtils.java
@@ -18,12 +18,13 @@ public class ScaResolverUtils {
     public static final String SCA_RESOLVER_FOR_LINUX = "/" + "ScaResolver";
     public static final String OFFLINE = "offline";
 
-    public static int runScaResolver(String pathToScaResolver, ArrayList<String> mandatoryList , String scaResolverAddParams, String pathToResultJSONFile, Logger log, ScaConfig scaConfig, ScaProperties scaProperties,String custom)
+    public static int runScaResolver(String pathToScaResolver, ArrayList<String> mandatoryList, ArrayList<String> exploitableList, String scaResolverAddParams, String pathToResultJSONFile, Logger log, ScaConfig scaConfig, ScaProperties scaProperties,String custom)
             throws CxHTTPClientException {
         int exitCode = -100;
         String[] scaResolverCommand;
 
         ArrayList<String> arguments = new ArrayList<>(mandatoryList);
+        arguments.addAll(exploitableList);
 
         Matcher m1 = Pattern.compile("([^\"]\\S*|\".+?\")\\s*").matcher(scaResolverAddParams);
         while (m1.find())

--- a/src/main/java/com/checkmarx/sdk/utils/scaResolver/ScaResolverUtils.java
+++ b/src/main/java/com/checkmarx/sdk/utils/scaResolver/ScaResolverUtils.java
@@ -71,7 +71,7 @@ public class ScaResolverUtils {
                 }
             }
         }
-        //Overridng sca properties project name params
+        //Overriding sca properties project name params
         if(scaProperties.getScaResolverOverrideProjectName()!=null)
         {
             for(int i=0;i<arguments.size();i++)
@@ -145,7 +145,7 @@ public class ScaResolverUtils {
             exitCode = process.waitFor();
 
         } catch (IOException | InterruptedException e) {
-            log.error("Failed to execute next command : " + scaResolverCommand, e.getMessage(), e.getStackTrace());
+            log.error("Failed to execute next command : " + Arrays.toString(scaResolverCommand), e.getMessage(), e.getStackTrace());
             Thread.currentThread().interrupt();
             if (Thread.interrupted()) {
                 throw new CxHTTPClientException(e);

--- a/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
+++ b/src/main/java/com/checkmarx/sdk/utils/scanner/client/ScaClientHelper.java
@@ -411,7 +411,6 @@ public class ScaClientHelper extends ScanClientHelper implements IScanClientHelp
         File sastResultFile = null;
         log.info("Executing SCA Resolver flow.");
         log.info("Path to Sca Resolver: {}", scaProperties.getPathToScaResolver());
-        //log.info("Sca Resolver Additional Parameters: {}", additionalParameters);
         File zipFile =null;
         int exitCode = ScaResolverUtils.runScaResolver(scaProperties.getPathToScaResolver(),createMandatoryList(sourceDir,projectName,scaResultPath),exploitablePath,additionalParameters,scaResultPath,log,scaConfig,scaProperties,customParameters);
         try {
@@ -423,7 +422,6 @@ public class ScaClientHelper extends ScanClientHelper implements IScanClientHelp
                 {
                     int index = exploitablePath.indexOf(CX_SAST_RESULT_PATH);
                     sastResultPath = exploitablePath.get(index+1);
-                    //sastResultPath = getSastResultFilePathFromAdditionalParams(additionalParameters);
                     sastResultFile = new File(sastResultPath);
                     resultToZip.add(sastResultFile);
                 }
@@ -509,7 +507,6 @@ public class ScaClientHelper extends ScanClientHelper implements IScanClientHelp
                 String finalPath = path + File.separator +SAST_RESOLVER_RESULT_FILE_NAME;
                 exploitableList.add(finalPath);
             }
-            log.debug("Exploitable path details:{}", exploitableList);
         }
         return exploitableList;
     }


### PR DESCRIPTION
SAST project name with spaces and preserve-project-name: true, ScaResolver fails to get SAST project due to spaces.  

Tested with SAST 9.7 with exploitable queries.